### PR TITLE
feat: add Flux image update automation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.schemas/*.json linguist-generated

--- a/.schemas/Makefile
+++ b/.schemas/Makefile
@@ -5,6 +5,10 @@ KUBECONFORM_VERSION := v0.6.1
 
 CRDS := \
 	https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.crds.yaml \
+	https://raw.githubusercontent.com/fluxcd/image-automation-controller/v0.33.0/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml \
+	https://raw.githubusercontent.com/fluxcd/image-reflector-controller/v0.27.1/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml \
+	https://raw.githubusercontent.com/fluxcd/image-reflector-controller/v0.27.1/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml \
+	https://raw.githubusercontent.com/fluxcd/source-controller/v1.0.0-rc.2/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml \
 	https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.57.0/jsonnet/prometheus-operator/podmonitors-crd.json \
 	https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.57.0/jsonnet/prometheus-operator/prometheuses-crd.json \
 

--- a/.schemas/gitrepository-source-v1.json
+++ b/.schemas/gitrepository-source-v1.json
@@ -1,0 +1,383 @@
+{
+  "description": "GitRepository is the Schema for the gitrepositories API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "GitRepositorySpec specifies the required configuration to produce an Artifact for a Git repository.",
+      "properties": {
+        "ignore": {
+          "description": "Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.",
+          "type": "string"
+        },
+        "include": {
+          "description": "Include specifies a list of GitRepository resources which Artifacts should be included in the Artifact produced for this GitRepository.",
+          "items": {
+            "description": "GitRepositoryInclude specifies a local reference to a GitRepository which Artifact (sub-)contents must be included, and where they should be placed.",
+            "properties": {
+              "fromPath": {
+                "description": "FromPath specifies the path to copy contents from, defaults to the root of the Artifact.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "GitRepositoryRef specifies the GitRepository which Artifact contents must be included.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "toPath": {
+                "description": "ToPath specifies the path to copy contents to, defaults to the name of the GitRepositoryRef.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "interval": {
+          "description": "Interval at which to check the GitRepository for updates.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "recurseSubmodules": {
+          "description": "RecurseSubmodules enables the initialization of all submodules within the GitRepository as cloned from the URL, using their default settings.",
+          "type": "boolean"
+        },
+        "ref": {
+          "description": "Reference specifies the Git reference to resolve and monitor for changes, defaults to the 'master' branch.",
+          "properties": {
+            "branch": {
+              "description": "Branch to check out, defaults to 'master' if no other field is defined.",
+              "type": "string"
+            },
+            "commit": {
+              "description": "Commit SHA to check out, takes precedence over all reference fields. \n This can be combined with Branch to shallow clone the branch, in which the commit is expected to exist.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the reference to check out; takes precedence over Branch, Tag and SemVer. \n It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description Examples: \"refs/heads/main\", \"refs/tags/v0.1.0\", \"refs/pull/420/head\", \"refs/merge-requests/1/head\"",
+              "type": "string"
+            },
+            "semver": {
+              "description": "SemVer tag expression to check out, takes precedence over Tag.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag to check out, takes precedence over Branch.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "SecretRef specifies the Secret containing authentication credentials for the GitRepository. For HTTPS repositories the Secret must contain 'username' and 'password' fields for basic auth or 'bearerToken' field for token auth. For SSH repositories the Secret must contain 'identity' and 'known_hosts' fields.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "suspend": {
+          "description": "Suspend tells the controller to suspend the reconciliation of this GitRepository.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": "60s",
+          "description": "Timeout for Git operations like cloning, defaults to 60s.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m))+$",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL specifies the Git repository URL, it can be an HTTP/S or SSH address.",
+          "pattern": "^(http|https|ssh)://.*$",
+          "type": "string"
+        },
+        "verify": {
+          "description": "Verification specifies the configuration to verify the Git commit signature(s).",
+          "properties": {
+            "mode": {
+              "description": "Mode specifies what Git object should be verified, currently ('head').",
+              "enum": [
+                "head"
+              ],
+              "type": "string"
+            },
+            "secretRef": {
+              "description": "SecretRef specifies the Secret containing the public keys of trusted Git authors.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "mode",
+            "secretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "interval",
+        "url"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "GitRepositoryStatus records the observed state of a Git repository.",
+      "properties": {
+        "artifact": {
+          "description": "Artifact represents the last successful GitRepository reconciliation.",
+          "properties": {
+            "digest": {
+              "description": "Digest is the digest of the file in the form of '<algorithm>:<checksum>'.",
+              "pattern": "^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$",
+              "type": "string"
+            },
+            "lastUpdateTime": {
+              "description": "LastUpdateTime is the timestamp corresponding to the last update of the Artifact.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "metadata": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Metadata holds upstream information such as OCI annotations.",
+              "type": "object"
+            },
+            "path": {
+              "description": "Path is the relative file path of the Artifact. It can be used to locate the file in the root of the Artifact storage on the local file system of the controller managing the Source.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "Revision is a human-readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.",
+              "type": "string"
+            },
+            "size": {
+              "description": "Size is the number of bytes in the file.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "url": {
+              "description": "URL is the HTTP address of the Artifact as exposed by the controller managing the Source. It can be used to retrieve the Artifact for consumption, e.g. by another controller applying the Artifact contents.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "lastUpdateTime",
+            "path",
+            "revision",
+            "url"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions holds the conditions for the GitRepository.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "includedArtifacts": {
+          "description": "IncludedArtifacts contains a list of the last successfully included Artifacts as instructed by GitRepositorySpec.Include.",
+          "items": {
+            "description": "Artifact represents the output of a Source reconciliation.",
+            "properties": {
+              "digest": {
+                "description": "Digest is the digest of the file in the form of '<algorithm>:<checksum>'.",
+                "pattern": "^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "LastUpdateTime is the timestamp corresponding to the last update of the Artifact.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Metadata holds upstream information such as OCI annotations.",
+                "type": "object"
+              },
+              "path": {
+                "description": "Path is the relative file path of the Artifact. It can be used to locate the file in the root of the Artifact storage on the local file system of the controller managing the Source.",
+                "type": "string"
+              },
+              "revision": {
+                "description": "Revision is a human-readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.",
+                "type": "string"
+              },
+              "size": {
+                "description": "Size is the number of bytes in the file.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "url": {
+                "description": "URL is the HTTP address of the Artifact as exposed by the controller managing the Source. It can be used to retrieve the Artifact for consumption, e.g. by another controller applying the Artifact contents.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastUpdateTime",
+              "path",
+              "revision",
+              "url"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last observed generation of the GitRepository object.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "observedIgnore": {
+          "description": "ObservedIgnore is the observed exclusion patterns used for constructing the source artifact.",
+          "type": "string"
+        },
+        "observedInclude": {
+          "description": "ObservedInclude is the observed list of GitRepository resources used to produce the current Artifact.",
+          "items": {
+            "description": "GitRepositoryInclude specifies a local reference to a GitRepository which Artifact (sub-)contents must be included, and where they should be placed.",
+            "properties": {
+              "fromPath": {
+                "description": "FromPath specifies the path to copy contents from, defaults to the root of the Artifact.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "GitRepositoryRef specifies the GitRepository which Artifact contents must be included.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "toPath": {
+                "description": "ToPath specifies the path to copy contents to, defaults to the name of the GitRepositoryRef.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedRecurseSubmodules": {
+          "description": "ObservedRecurseSubmodules is the observed resource submodules configuration used to produce the current Artifact.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/gitrepository-source-v1beta1.json
+++ b/.schemas/gitrepository-source-v1beta1.json
@@ -1,0 +1,343 @@
+{
+  "description": "GitRepository is the Schema for the gitrepositories API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "GitRepositorySpec defines the desired state of a Git repository.",
+      "properties": {
+        "accessFrom": {
+          "description": "AccessFrom defines an Access Control List for allowing cross-namespace references to this object.",
+          "properties": {
+            "namespaceSelectors": {
+              "description": "NamespaceSelectors is the list of namespace selectors to which this ACL applies. Items in this list are evaluated using a logical OR operation.",
+              "items": {
+                "description": "NamespaceSelector selects the namespaces to which this ACL applies. An empty map of MatchLabels matches all namespaces in a cluster.",
+                "properties": {
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "namespaceSelectors"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gitImplementation": {
+          "default": "go-git",
+          "description": "Determines which git client library to use. Defaults to go-git, valid values are ('go-git', 'libgit2').",
+          "enum": [
+            "go-git",
+            "libgit2"
+          ],
+          "type": "string"
+        },
+        "ignore": {
+          "description": "Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.",
+          "type": "string"
+        },
+        "include": {
+          "description": "Extra git repositories to map into the repository",
+          "items": {
+            "description": "GitRepositoryInclude defines a source with a from and to path.",
+            "properties": {
+              "fromPath": {
+                "description": "The path to copy contents from, defaults to the root directory.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "Reference to a GitRepository to include.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "toPath": {
+                "description": "The path to copy contents to, defaults to the name of the source ref.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "interval": {
+          "description": "The interval at which to check for repository updates.",
+          "type": "string"
+        },
+        "recurseSubmodules": {
+          "description": "When enabled, after the clone is created, initializes all submodules within, using their default settings. This option is available only when using the 'go-git' GitImplementation.",
+          "type": "boolean"
+        },
+        "ref": {
+          "description": "The Git reference to checkout and monitor for changes, defaults to master branch.",
+          "properties": {
+            "branch": {
+              "description": "The Git branch to checkout, defaults to master.",
+              "type": "string"
+            },
+            "commit": {
+              "description": "The Git commit SHA to checkout, if specified Tag filters will be ignored.",
+              "type": "string"
+            },
+            "semver": {
+              "description": "The Git tag semver expression, takes precedence over Tag.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "The Git tag to checkout, takes precedence over Branch.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity and known_hosts fields.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "suspend": {
+          "description": "This flag tells the controller to suspend the reconciliation of this source.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": "60s",
+          "description": "The timeout for remote Git operations like cloning, defaults to 60s.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The repository URL, can be a HTTP/S or SSH address.",
+          "pattern": "^(http|https|ssh)://.*$",
+          "type": "string"
+        },
+        "verify": {
+          "description": "Verify OpenPGP signature for the Git commit HEAD points to.",
+          "properties": {
+            "mode": {
+              "description": "Mode describes what git object should be verified, currently ('head').",
+              "enum": [
+                "head"
+              ],
+              "type": "string"
+            },
+            "secretRef": {
+              "description": "The secret name containing the public keys of all trusted Git authors.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "mode"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "interval",
+        "url"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "GitRepositoryStatus defines the observed state of a Git repository.",
+      "properties": {
+        "artifact": {
+          "description": "Artifact represents the output of the last successful repository sync.",
+          "properties": {
+            "checksum": {
+              "description": "Checksum is the SHA256 checksum of the artifact.",
+              "type": "string"
+            },
+            "lastUpdateTime": {
+              "description": "LastUpdateTime is the timestamp corresponding to the last update of this artifact.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "path": {
+              "description": "Path is the relative file path of this artifact.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.",
+              "type": "string"
+            },
+            "url": {
+              "description": "URL is the HTTP address of this artifact.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "url"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions holds the conditions for the GitRepository.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "includedArtifacts": {
+          "description": "IncludedArtifacts represents the included artifacts from the last successful repository sync.",
+          "items": {
+            "description": "Artifact represents the output of a source synchronisation.",
+            "properties": {
+              "checksum": {
+                "description": "Checksum is the SHA256 checksum of the artifact.",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "LastUpdateTime is the timestamp corresponding to the last update of this artifact.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path is the relative file path of this artifact.",
+                "type": "string"
+              },
+              "revision": {
+                "description": "Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL is the HTTP address of this artifact.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path",
+              "url"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last observed generation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "url": {
+          "description": "URL is the download link for the artifact output of the last repository sync.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/gitrepository-source-v1beta2.json
+++ b/.schemas/gitrepository-source-v1beta2.json
@@ -1,0 +1,428 @@
+{
+  "description": "GitRepository is the Schema for the gitrepositories API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "GitRepositorySpec specifies the required configuration to produce an Artifact for a Git repository.",
+      "properties": {
+        "accessFrom": {
+          "description": "AccessFrom specifies an Access Control List for allowing cross-namespace references to this object. NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092",
+          "properties": {
+            "namespaceSelectors": {
+              "description": "NamespaceSelectors is the list of namespace selectors to which this ACL applies. Items in this list are evaluated using a logical OR operation.",
+              "items": {
+                "description": "NamespaceSelector selects the namespaces to which this ACL applies. An empty map of MatchLabels matches all namespaces in a cluster.",
+                "properties": {
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "namespaceSelectors"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gitImplementation": {
+          "default": "go-git",
+          "description": "GitImplementation specifies which Git client library implementation to use. Defaults to 'go-git', valid values are ('go-git', 'libgit2'). Deprecated: gitImplementation is deprecated now that 'go-git' is the only supported implementation.",
+          "enum": [
+            "go-git",
+            "libgit2"
+          ],
+          "type": "string"
+        },
+        "ignore": {
+          "description": "Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.",
+          "type": "string"
+        },
+        "include": {
+          "description": "Include specifies a list of GitRepository resources which Artifacts should be included in the Artifact produced for this GitRepository.",
+          "items": {
+            "description": "GitRepositoryInclude specifies a local reference to a GitRepository which Artifact (sub-)contents must be included, and where they should be placed.",
+            "properties": {
+              "fromPath": {
+                "description": "FromPath specifies the path to copy contents from, defaults to the root of the Artifact.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "GitRepositoryRef specifies the GitRepository which Artifact contents must be included.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "toPath": {
+                "description": "ToPath specifies the path to copy contents to, defaults to the name of the GitRepositoryRef.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "interval": {
+          "description": "Interval at which to check the GitRepository for updates.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "recurseSubmodules": {
+          "description": "RecurseSubmodules enables the initialization of all submodules within the GitRepository as cloned from the URL, using their default settings.",
+          "type": "boolean"
+        },
+        "ref": {
+          "description": "Reference specifies the Git reference to resolve and monitor for changes, defaults to the 'master' branch.",
+          "properties": {
+            "branch": {
+              "description": "Branch to check out, defaults to 'master' if no other field is defined.",
+              "type": "string"
+            },
+            "commit": {
+              "description": "Commit SHA to check out, takes precedence over all reference fields. \n This can be combined with Branch to shallow clone the branch, in which the commit is expected to exist.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the reference to check out; takes precedence over Branch, Tag and SemVer. \n It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description Examples: \"refs/heads/main\", \"refs/tags/v0.1.0\", \"refs/pull/420/head\", \"refs/merge-requests/1/head\"",
+              "type": "string"
+            },
+            "semver": {
+              "description": "SemVer tag expression to check out, takes precedence over Tag.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag to check out, takes precedence over Branch.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "SecretRef specifies the Secret containing authentication credentials for the GitRepository. For HTTPS repositories the Secret must contain 'username' and 'password' fields for basic auth or 'bearerToken' field for token auth. For SSH repositories the Secret must contain 'identity' and 'known_hosts' fields.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "suspend": {
+          "description": "Suspend tells the controller to suspend the reconciliation of this GitRepository.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": "60s",
+          "description": "Timeout for Git operations like cloning, defaults to 60s.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m))+$",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL specifies the Git repository URL, it can be an HTTP/S or SSH address.",
+          "pattern": "^(http|https|ssh)://.*$",
+          "type": "string"
+        },
+        "verify": {
+          "description": "Verification specifies the configuration to verify the Git commit signature(s).",
+          "properties": {
+            "mode": {
+              "description": "Mode specifies what Git object should be verified, currently ('head').",
+              "enum": [
+                "head"
+              ],
+              "type": "string"
+            },
+            "secretRef": {
+              "description": "SecretRef specifies the Secret containing the public keys of trusted Git authors.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "mode",
+            "secretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "interval",
+        "url"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "GitRepositoryStatus records the observed state of a Git repository.",
+      "properties": {
+        "artifact": {
+          "description": "Artifact represents the last successful GitRepository reconciliation.",
+          "properties": {
+            "digest": {
+              "description": "Digest is the digest of the file in the form of '<algorithm>:<checksum>'.",
+              "pattern": "^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$",
+              "type": "string"
+            },
+            "lastUpdateTime": {
+              "description": "LastUpdateTime is the timestamp corresponding to the last update of the Artifact.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "metadata": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Metadata holds upstream information such as OCI annotations.",
+              "type": "object"
+            },
+            "path": {
+              "description": "Path is the relative file path of the Artifact. It can be used to locate the file in the root of the Artifact storage on the local file system of the controller managing the Source.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "Revision is a human-readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.",
+              "type": "string"
+            },
+            "size": {
+              "description": "Size is the number of bytes in the file.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "url": {
+              "description": "URL is the HTTP address of the Artifact as exposed by the controller managing the Source. It can be used to retrieve the Artifact for consumption, e.g. by another controller applying the Artifact contents.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "lastUpdateTime",
+            "path",
+            "revision",
+            "url"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions holds the conditions for the GitRepository.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "contentConfigChecksum": {
+          "description": "ContentConfigChecksum is a checksum of all the configurations related to the content of the source artifact: - .spec.ignore - .spec.recurseSubmodules - .spec.included and the checksum of the included artifacts observed in .status.observedGeneration version of the object. This can be used to determine if the content of the included repository has changed. It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`. \n Deprecated: Replaced with explicit fields for observed artifact content config in the status.",
+          "type": "string"
+        },
+        "includedArtifacts": {
+          "description": "IncludedArtifacts contains a list of the last successfully included Artifacts as instructed by GitRepositorySpec.Include.",
+          "items": {
+            "description": "Artifact represents the output of a Source reconciliation.",
+            "properties": {
+              "digest": {
+                "description": "Digest is the digest of the file in the form of '<algorithm>:<checksum>'.",
+                "pattern": "^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "LastUpdateTime is the timestamp corresponding to the last update of the Artifact.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Metadata holds upstream information such as OCI annotations.",
+                "type": "object"
+              },
+              "path": {
+                "description": "Path is the relative file path of the Artifact. It can be used to locate the file in the root of the Artifact storage on the local file system of the controller managing the Source.",
+                "type": "string"
+              },
+              "revision": {
+                "description": "Revision is a human-readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.",
+                "type": "string"
+              },
+              "size": {
+                "description": "Size is the number of bytes in the file.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "url": {
+                "description": "URL is the HTTP address of the Artifact as exposed by the controller managing the Source. It can be used to retrieve the Artifact for consumption, e.g. by another controller applying the Artifact contents.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastUpdateTime",
+              "path",
+              "revision",
+              "url"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last observed generation of the GitRepository object.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "observedIgnore": {
+          "description": "ObservedIgnore is the observed exclusion patterns used for constructing the source artifact.",
+          "type": "string"
+        },
+        "observedInclude": {
+          "description": "ObservedInclude is the observed list of GitRepository resources used to to produce the current Artifact.",
+          "items": {
+            "description": "GitRepositoryInclude specifies a local reference to a GitRepository which Artifact (sub-)contents must be included, and where they should be placed.",
+            "properties": {
+              "fromPath": {
+                "description": "FromPath specifies the path to copy contents from, defaults to the root of the Artifact.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "GitRepositoryRef specifies the GitRepository which Artifact contents must be included.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "toPath": {
+                "description": "ToPath specifies the path to copy contents to, defaults to the name of the GitRepositoryRef.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedRecurseSubmodules": {
+          "description": "ObservedRecurseSubmodules is the observed resource submodules configuration used to produce the current Artifact.",
+          "type": "boolean"
+        },
+        "url": {
+          "description": "URL is the dynamic fetch link for the latest Artifact. It is provided on a \"best effort\" basis, and using the precise GitRepositoryStatus.Artifact data is recommended.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/imagepolicy-image-v1beta1.json
+++ b/.schemas/imagepolicy-image-v1beta1.json
@@ -1,0 +1,188 @@
+{
+  "description": "ImagePolicy is the Schema for the imagepolicies API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImagePolicySpec defines the parameters for calculating the ImagePolicy",
+      "properties": {
+        "filterTags": {
+          "description": "FilterTags enables filtering for only a subset of tags based on a set of rules. If no rules are provided, all the tags from the repository will be ordered and compared.",
+          "properties": {
+            "extract": {
+              "description": "Extract allows a capture group to be extracted from the specified regular expression pattern, useful before tag evaluation.",
+              "type": "string"
+            },
+            "pattern": {
+              "description": "Pattern specifies a regular expression pattern used to filter for image tags.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageRepositoryRef": {
+          "description": "ImageRepositoryRef points at the object specifying the image being scanned",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent, when not specified it acts as LocalObjectReference.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "policy": {
+          "description": "Policy gives the particulars of the policy to be followed in selecting the most recent image",
+          "properties": {
+            "alphabetical": {
+              "description": "Alphabetical set of rules to use for alphabetical ordering of the tags.",
+              "properties": {
+                "order": {
+                  "default": "asc",
+                  "description": "Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A.",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "numerical": {
+              "description": "Numerical set of rules to use for numerical ordering of the tags.",
+              "properties": {
+                "order": {
+                  "default": "asc",
+                  "description": "Order specifies the sorting order of the tags. Given the integer values from 0 to 9 as tags, ascending order would select 9, and descending order would select 0.",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "semver": {
+              "description": "SemVer gives a semantic version range to check against the tags available.",
+              "properties": {
+                "range": {
+                  "description": "Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "range"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "imageRepositoryRef",
+        "policy"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "ImagePolicyStatus defines the observed state of ImagePolicy",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "latestImage": {
+          "description": "LatestImage gives the first in the list of images scanned by the image repository, when filtered and ordered according to the policy.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/imagepolicy-image-v1beta2.json
+++ b/.schemas/imagepolicy-image-v1beta2.json
@@ -1,0 +1,192 @@
+{
+  "description": "ImagePolicy is the Schema for the imagepolicies API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImagePolicySpec defines the parameters for calculating the ImagePolicy.",
+      "properties": {
+        "filterTags": {
+          "description": "FilterTags enables filtering for only a subset of tags based on a set of rules. If no rules are provided, all the tags from the repository will be ordered and compared.",
+          "properties": {
+            "extract": {
+              "description": "Extract allows a capture group to be extracted from the specified regular expression pattern, useful before tag evaluation.",
+              "type": "string"
+            },
+            "pattern": {
+              "description": "Pattern specifies a regular expression pattern used to filter for image tags.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageRepositoryRef": {
+          "description": "ImageRepositoryRef points at the object specifying the image being scanned",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent, when not specified it acts as LocalObjectReference.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "policy": {
+          "description": "Policy gives the particulars of the policy to be followed in selecting the most recent image",
+          "properties": {
+            "alphabetical": {
+              "description": "Alphabetical set of rules to use for alphabetical ordering of the tags.",
+              "properties": {
+                "order": {
+                  "default": "asc",
+                  "description": "Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A.",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "numerical": {
+              "description": "Numerical set of rules to use for numerical ordering of the tags.",
+              "properties": {
+                "order": {
+                  "default": "asc",
+                  "description": "Order specifies the sorting order of the tags. Given the integer values from 0 to 9 as tags, ascending order would select 9, and descending order would select 0.",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "semver": {
+              "description": "SemVer gives a semantic version range to check against the tags available.",
+              "properties": {
+                "range": {
+                  "description": "Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "range"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "imageRepositoryRef",
+        "policy"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "ImagePolicyStatus defines the observed state of ImagePolicy",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "latestImage": {
+          "description": "LatestImage gives the first in the list of images scanned by the image repository, when filtered and ordered according to the policy.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "observedPreviousImage": {
+          "description": "ObservedPreviousImage is the observed previous LatestImage. It is used to keep track of the previous and current images.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/imagerepository-image-v1beta1.json
+++ b/.schemas/imagerepository-image-v1beta1.json
@@ -1,0 +1,206 @@
+{
+  "description": "ImageRepository is the Schema for the imagerepositories API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.",
+      "properties": {
+        "accessFrom": {
+          "description": "AccessFrom defines an ACL for allowing cross-namespace references to the ImageRepository object based on the caller's namespace labels.",
+          "properties": {
+            "namespaceSelectors": {
+              "description": "NamespaceSelectors is the list of namespace selectors to which this ACL applies. Items in this list are evaluated using a logical OR operation.",
+              "items": {
+                "description": "NamespaceSelector selects the namespaces to which this ACL applies. An empty map of MatchLabels matches all namespaces in a cluster.",
+                "properties": {
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "namespaceSelectors"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "certSecretRef": {
+          "description": "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "exclusionList": {
+          "description": "ExclusionList is a list of regex strings used to exclude certain tags from being stored in the database.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Image is the name of the image repository",
+          "type": "string"
+        },
+        "interval": {
+          "description": "Interval is the length of time to wait between scans of the image repository.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "secretRef": {
+          "description": "SecretRef can be given the name of a secret containing credentials to use for the image registry. The secret should be created with `kubectl create secret docker-registry`, or the equivalent.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate the image pull if the service account has attached pull secrets.",
+          "maxLength": 253,
+          "type": "string"
+        },
+        "suspend": {
+          "description": "This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Timeout for image scanning. Defaults to 'Interval' duration.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m))+$",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "ImageRepositoryStatus defines the observed state of ImageRepository",
+      "properties": {
+        "canonicalImageName": {
+          "description": "CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`.",
+          "type": "string"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "lastScanResult": {
+          "description": "LastScanResult contains the number of fetched tags.",
+          "properties": {
+            "scanTime": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "tagCount": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "tagCount"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last reconciled generation.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/imagerepository-image-v1beta2.json
+++ b/.schemas/imagerepository-image-v1beta2.json
@@ -1,0 +1,234 @@
+{
+  "description": "ImageRepository is the Schema for the imagerepositories API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.",
+      "properties": {
+        "accessFrom": {
+          "description": "AccessFrom defines an ACL for allowing cross-namespace references to the ImageRepository object based on the caller's namespace labels.",
+          "properties": {
+            "namespaceSelectors": {
+              "description": "NamespaceSelectors is the list of namespace selectors to which this ACL applies. Items in this list are evaluated using a logical OR operation.",
+              "items": {
+                "description": "NamespaceSelector selects the namespaces to which this ACL applies. An empty map of MatchLabels matches all namespaces in a cluster.",
+                "properties": {
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "namespaceSelectors"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "certSecretRef": {
+          "description": "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "exclusionList": {
+          "default": [
+            "^.*\\.sig$"
+          ],
+          "description": "ExclusionList is a list of regex strings used to exclude certain tags from being stored in the database.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 25,
+          "type": "array"
+        },
+        "image": {
+          "description": "Image is the name of the image repository",
+          "type": "string"
+        },
+        "interval": {
+          "description": "Interval is the length of time to wait between scans of the image repository.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "provider": {
+          "default": "generic",
+          "description": "The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'. When not specified, defaults to 'generic'.",
+          "enum": [
+            "generic",
+            "aws",
+            "azure",
+            "gcp"
+          ],
+          "type": "string"
+        },
+        "secretRef": {
+          "description": "SecretRef can be given the name of a secret containing credentials to use for the image registry. The secret should be created with `kubectl create secret docker-registry`, or the equivalent.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate the image pull if the service account has attached pull secrets.",
+          "maxLength": 253,
+          "type": "string"
+        },
+        "suspend": {
+          "description": "This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Timeout for image scanning. Defaults to 'Interval' duration.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m))+$",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "ImageRepositoryStatus defines the observed state of ImageRepository",
+      "properties": {
+        "canonicalImageName": {
+          "description": "CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`.",
+          "type": "string"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "lastScanResult": {
+          "description": "LastScanResult contains the number of fetched tags.",
+          "properties": {
+            "latestTags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "scanTime": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "tagCount": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "tagCount"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedExclusionList": {
+          "description": "ObservedExclusionList is a list of observed exclusion list. It reflects the exclusion rules used for the observed scan result in spec.lastScanResult.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last reconciled generation.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/imageupdateautomation-image-v1beta1.json
+++ b/.schemas/imageupdateautomation-image-v1beta1.json
@@ -1,0 +1,295 @@
+{
+  "description": "ImageUpdateAutomation is the Schema for the imageupdateautomations API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation",
+      "properties": {
+        "git": {
+          "description": "GitSpec contains all the git-specific definitions. This is technically optional, but in practice mandatory until there are other kinds of source allowed.",
+          "properties": {
+            "checkout": {
+              "description": "Checkout gives the parameters for cloning the git repository, ready to make changes. If not present, the `spec.ref` field from the referenced `GitRepository` or its default will be used.",
+              "properties": {
+                "ref": {
+                  "description": "Reference gives a branch, tag or commit to clone from the Git repository.",
+                  "properties": {
+                    "branch": {
+                      "description": "Branch to check out, defaults to 'master' if no other field is defined.",
+                      "type": "string"
+                    },
+                    "commit": {
+                      "description": "Commit SHA to check out, takes precedence over all reference fields. \n This can be combined with Branch to shallow clone the branch, in which the commit is expected to exist.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the reference to check out; takes precedence over Branch, Tag and SemVer. \n It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description Examples: \"refs/heads/main\", \"refs/tags/v0.1.0\", \"refs/pull/420/head\", \"refs/merge-requests/1/head\"",
+                      "type": "string"
+                    },
+                    "semver": {
+                      "description": "SemVer tag expression to check out, takes precedence over Tag.",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Tag to check out, takes precedence over Branch.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "commit": {
+              "description": "Commit specifies how to commit to the git repository.",
+              "properties": {
+                "author": {
+                  "description": "Author gives the email and optionally the name to use as the author of commits.",
+                  "properties": {
+                    "email": {
+                      "description": "Email gives the email to provide when making a commit.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name gives the name to provide when making a commit.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "messageTemplate": {
+                  "description": "MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made.",
+                  "type": "string"
+                },
+                "signingKey": {
+                  "description": "SigningKey provides the option to sign commits with a GPG key",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef holds the name to a secret that contains a 'git.asc' key corresponding to the ASCII Armored file containing the GPG signing keypair as the value. It must be in the same namespace as the ImageUpdateAutomation.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "author"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "push": {
+              "description": "Push specifies how and where to push commits made by the automation. If missing, commits are pushed (back) to `.spec.checkout.branch` or its default.",
+              "properties": {
+                "branch": {
+                  "description": "Branch specifies that commits should be pushed to the branch named. The branch is created using `.spec.checkout.branch` as the starting point, if it doesn't already exist.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "branch"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "commit"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "interval": {
+          "description": "Interval gives an lower bound for how often the automation run should be attempted.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "sourceRef": {
+          "description": "SourceRef refers to the resource giving access details to a git repository.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "default": "GitRepository",
+              "description": "Kind of the referent.",
+              "enum": [
+                "GitRepository"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent, defaults to the namespace of the Kubernetes resource object that contains the reference.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "suspend": {
+          "description": "Suspend tells the controller to not run this automation, until it is unset (or set to false). Defaults to false.",
+          "type": "boolean"
+        },
+        "update": {
+          "default": {
+            "strategy": "Setters"
+          },
+          "description": "Update gives the specification for how to update the files in the repository. This can be left empty, to use the default value.",
+          "properties": {
+            "path": {
+              "description": "Path to the directory containing the manifests to be updated. Defaults to 'None', which translates to the root path of the GitRepositoryRef.",
+              "type": "string"
+            },
+            "strategy": {
+              "default": "Setters",
+              "description": "Strategy names the strategy to be used.",
+              "enum": [
+                "Setters"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "strategy"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "interval",
+        "sourceRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "ImageUpdateAutomationStatus defines the observed state of ImageUpdateAutomation",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastAutomationRunTime": {
+          "description": "LastAutomationRunTime records the last time the controller ran this automation through to completion (even if no updates were made).",
+          "format": "date-time",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "lastPushCommit": {
+          "description": "LastPushCommit records the SHA1 of the last commit made by the controller, for this automation object",
+          "type": "string"
+        },
+        "lastPushTime": {
+          "description": "LastPushTime records the time of the last pushed change.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
+}

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Edit `.schemas/Makefile` to update them and use `make -C .schemas` to re-generat
 Validation can be performed by passing the manifest output to `kubeconform`:
 
 ```shell
-${COMMAND} | kubeconform
+${COMMAND} | kubeconform \
   -schema-location '.schemas/{{ .ResourceKind }}{{ .KindSuffix }}.json' \
   -schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master' \
   -skip CustomResourceDefinition \

--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -7,6 +7,16 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: flux-system
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: ingress-nginx
 ---
 apiVersion: v1

--- a/flux/README.md
+++ b/flux/README.md
@@ -1,0 +1,38 @@
+# Flux
+
+See [Automate image updates to Git | Flux](https://fluxcd.io/flux/guides/image-update/).
+
+> **Note**: There is an [argocd-image-updater](https://github.com/argoproj-labs/argocd-image-updater),
+> but it is very specific to Argo CD and supports Helm and Kustomize only.
+> Flux supports any YAML file and is agnostic regarding the deployment solution.
+
+## Configure SSH key
+
+Based on [Git Repositories - SSH authentication | Flux](https://fluxcd.io/flux/components/source/gitrepositories/#ssh-authentication).
+
+1. Generate a new SSH key pair:
+
+   ```bash
+   ssh-keygen -b 4096 -N '' -C fluxcdbot -f fluxcdbot
+   ```
+
+2. Create a new secret in the cluster:
+
+   ```bash
+   KNOWN_HOSTS="$(ssh-keyscan github.com)"
+   kubectl create secret generic \
+     --namespace=flux-system \
+     flux-ssh-credentials \
+     --from-literal=identity="$(<fluxcdbot)" \
+     --from-literal=known_hosts="${KNOWN_HOSTS}"
+   ```
+
+3. Add the `fluxcdbot.pub` public key to the repository's [deploy keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) with **write access**.
+
+## Retrieve current SSH public key from the cluster
+
+```bash
+kubectl get secret --namespace=flux-system flux-ssh-credentials --output=json \
+  | jq --raw-output '.data.identity|@base64d' \
+  | ssh-keygen -y -f /dev/stdin
+```

--- a/flux/README.md
+++ b/flux/README.md
@@ -19,12 +19,16 @@ Based on [Git Repositories - SSH authentication | Flux](https://fluxcd.io/flux/c
 2. Create a new secret in the cluster:
 
    ```bash
-   KNOWN_HOSTS="$(ssh-keyscan github.com)"
-   kubectl create secret generic \
+   PATCH="$(jq --null-input --arg identity "$(<fluxcdbot)" '[{
+     "op": "replace",
+     "path": "/data/identity",
+     "value": "\($identity|@base64)"
+   }]')"
+   kubectl patch secret \
      --namespace=flux-system \
      flux-ssh-credentials \
-     --from-literal=identity="$(<fluxcdbot)" \
-     --from-literal=known_hosts="${KNOWN_HOSTS}"
+     --type=json \
+     --patch="${PATCH}"
    ```
 
 3. Add the `fluxcdbot.pub` public key to the repository's [deploy keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) with **write access**.

--- a/flux/README.md
+++ b/flux/README.md
@@ -6,6 +6,26 @@ See [Automate image updates to Git | Flux](https://fluxcd.io/flux/guides/image-u
 > but it is very specific to Argo CD and supports Helm and Kustomize only.
 > Flux supports any YAML file and is agnostic regarding the deployment solution.
 
+## Suspend and resume reconciliation of Git repository
+
+### Suspend
+
+```bash
+kubectl patch GitRepository \
+  --namespace=flux-system parca-dev-demo-deployments \
+  --type=json --patch='[{ "op": "add", "path": "/spec/suspend", "value": true }]'
+```
+
+### Resume
+
+```bash
+kubectl patch GitRepository \
+  --namespace=flux-system parca-dev-demo-deployments \
+  --type=json --patch='[{ "op": "remove", "path": "/spec/suspend" }]'
+```
+
+See also [Git Repositories - Suspending and resuming | Flux](https://fluxcd.io/flux/components/source/gitrepositories/#suspending-and-resuming).
+
 ## Configure SSH key
 
 Based on [Git Repositories - SSH authentication | Flux](https://fluxcd.io/flux/components/source/gitrepositories/#ssh-authentication).
@@ -25,10 +45,8 @@ Based on [Git Repositories - SSH authentication | Flux](https://fluxcd.io/flux/c
      "value": "\($identity|@base64)"
    }]')"
    kubectl patch secret \
-     --namespace=flux-system \
-     flux-ssh-credentials \
-     --type=json \
-     --patch="${PATCH}"
+     --namespace=flux-system flux-ssh-credentials \
+     --type=json --patch="${PATCH}"
    ```
 
 3. Add the `fluxcdbot.pub` public key to the repository's [deploy keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) with **write access**.

--- a/flux/base/image-automation-controller/kustomization.yaml
+++ b/flux/base/image-automation-controller/kustomization.yaml
@@ -1,0 +1,63 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- github.com/fluxcd/image-automation-controller/config/default?ref=0ef6f98a1e5ce3ec0141f84b0189445e68342718 # v0.33.0
+- serviceaccount.yaml
+- networkpolicy.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/component: image-automation-controller
+  includeSelectors: true
+
+images:
+- name: fluxcd/image-automation-controller
+  newName: ghcr.io/fluxcd/image-automation-controller
+
+# Ignoring deprecation for now
+# https://github.com/kubernetes-sigs/kustomize/issues/5049
+patchesStrategicMerge:
+- patches/delete_namespace.yaml
+- patches/use_serviceaccount.yaml
+- patches/set_resources_limits_requests.yaml
+
+patches:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: image-automation-manager-role
+  patch: |-
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups:
+        - ""
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups:
+        - image.toolkit.fluxcd.io
+        resources:
+        - imagepolicies
+        verbs:
+        - get
+        - list
+        - watch
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: Role
+    name: image-automation-leader-election-role
+  patch: |-
+    # allow patching events
+    - op: add
+      path: /rules/2/verbs/-
+      value: patch

--- a/flux/base/image-automation-controller/networkpolicy.yaml
+++ b/flux/base/image-automation-controller/networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: image-automation-controller
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: image-automation-controller
+  policyTypes:
+  - Egress

--- a/flux/base/image-automation-controller/patches/delete_namespace.yaml
+++ b/flux/base/image-automation-controller/patches/delete_namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: image-automation-system
+$patch: delete

--- a/flux/base/image-automation-controller/patches/set_resources_limits_requests.yaml
+++ b/flux/base/image-automation-controller/patches/set_resources_limits_requests.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-automation-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: null
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/flux/base/image-automation-controller/patches/use_serviceaccount.yaml
+++ b/flux/base/image-automation-controller/patches/use_serviceaccount.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-automation-controller
+spec:
+  template:
+    spec:
+      serviceAccountName: image-automation-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: image-automation-leader-election-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: image-automation-controller
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: image-automation-manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: image-automation-controller
+  namespace: flux-system

--- a/flux/base/image-automation-controller/serviceaccount.yaml
+++ b/flux/base/image-automation-controller/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-automation-controller

--- a/flux/base/image-reflector-controller/kustomization.yaml
+++ b/flux/base/image-reflector-controller/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- github.com/fluxcd/image-reflector-controller/config/default?ref=82ff74a054c6a67d3f0798907e573668e91ed2f9 # v0.27.1
+- serviceaccount.yaml
+- networkpolicy.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/component: image-reflector-controller
+  includeSelectors: true
+
+images:
+- name: fluxcd/image-reflector-controller
+  newName: ghcr.io/fluxcd/image-reflector-controller
+
+# Ignoring deprecation for now
+# https://github.com/kubernetes-sigs/kustomize/issues/5049
+patchesStrategicMerge:
+- patches/delete_namespace.yaml
+- patches/use_serviceaccount.yaml
+- patches/set_resources_limits_requests.yaml
+
+patches:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: image-reflector-manager-role
+  patch: |-
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups:
+        - ""
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: Role
+    name: image-reflector-leader-election-role
+  patch: |-
+    # allow patching events
+    - op: add
+      path: /rules/2/verbs/-
+      value: patch

--- a/flux/base/image-reflector-controller/networkpolicy.yaml
+++ b/flux/base/image-reflector-controller/networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: image-reflector-controller
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: image-reflector-controller
+  policyTypes:
+  - Egress

--- a/flux/base/image-reflector-controller/patches/delete_namespace.yaml
+++ b/flux/base/image-reflector-controller/patches/delete_namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: image-reflector-system
+$patch: delete

--- a/flux/base/image-reflector-controller/patches/set_resources_limits_requests.yaml
+++ b/flux/base/image-reflector-controller/patches/set_resources_limits_requests.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-reflector-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: null
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/flux/base/image-reflector-controller/patches/use_serviceaccount.yaml
+++ b/flux/base/image-reflector-controller/patches/use_serviceaccount.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-reflector-controller
+spec:
+  template:
+    spec:
+      serviceAccountName: image-reflector-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: image-reflector-leader-election-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: image-reflector-controller
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: image-reflector-manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: image-reflector-controller
+  namespace: flux-system

--- a/flux/base/image-reflector-controller/serviceaccount.yaml
+++ b/flux/base/image-reflector-controller/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-reflector-controller

--- a/flux/base/kustomization.yaml
+++ b/flux/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- image-automation-controller
+- image-reflector-controller
+- source-controller
+
+labels:
+- pairs:
+    app.kubernetes.io/name: flux
+  includeSelectors: true

--- a/flux/base/source-controller/kustomization.yaml
+++ b/flux/base/source-controller/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- github.com/fluxcd/source-controller/config/default?ref=5887114d3cf2eda8774b9b62540f245851f514d8 # v1.0.0-rc.2
+- serviceaccount.yaml
+- networkpolicy.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/component: source-controller
+  includeSelectors: true
+
+images:
+- name: fluxcd/source-controller
+  newName: ghcr.io/fluxcd/source-controller
+
+# Ignoring deprecation for now
+# https://github.com/kubernetes-sigs/kustomize/issues/5049
+patchesStrategicMerge:
+- patches/delete_namespace.yaml
+- patches/use_serviceaccount.yaml
+- patches/set_resources_limits_requests.yaml

--- a/flux/base/source-controller/networkpolicy.yaml
+++ b/flux/base/source-controller/networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: source-controller
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: source-controller
+  policyTypes:
+  - Egress

--- a/flux/base/source-controller/patches/delete_namespace.yaml
+++ b/flux/base/source-controller/patches/delete_namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: source-system
+$patch: delete

--- a/flux/base/source-controller/patches/set_resources_limits_requests.yaml
+++ b/flux/base/source-controller/patches/set_resources_limits_requests.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: source-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: null
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/flux/base/source-controller/patches/use_serviceaccount.yaml
+++ b/flux/base/source-controller/patches/use_serviceaccount.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: source-controller
+spec:
+  template:
+    spec:
+      serviceAccountName: source-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: source-leader-election-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: source-controller
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: source-manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: source-controller
+  namespace: flux-system

--- a/flux/base/source-controller/serviceaccount.yaml
+++ b/flux/base/source-controller/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: source-controller

--- a/flux/overlays/scaleway-parca-demo/gitrepository.yaml
+++ b/flux/overlays/scaleway-parca-demo/gitrepository.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: parca-dev-demo-deployments
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: ssh://git@github.com/parca-dev/demo-deployments.git
+  secretRef:
+    name: flux-ssh-credentials

--- a/flux/overlays/scaleway-parca-demo/imagepolicies.yaml
+++ b/flux/overlays/scaleway-parca-demo/imagepolicies.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: parca
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^main-(?P<ts>[1-9][0-9]*)-[a-fA-F0-9]+'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: parca
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: parca-agent
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^main-(?P<ts>[1-9][0-9]*)-[a-fA-F0-9]+'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: parca-agent

--- a/flux/overlays/scaleway-parca-demo/imagerepositories.yaml
+++ b/flux/overlays/scaleway-parca-demo/imagerepositories.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: parca
+spec:
+  interval: 1m0s
+  image: ghcr.io/parca-dev/parca
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: parca-agent
+spec:
+  interval: 1m0s
+  image: ghcr.io/parca-dev/parca-agent

--- a/flux/overlays/scaleway-parca-demo/imageupdateautomation.yaml
+++ b/flux/overlays/scaleway-parca-demo/imageupdateautomation.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: parca-dev-demo-deployments
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: parca-dev-demo-deployments
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |-
+        chore(deploy): update {{ range $i, $image := .Updated.Images -}}
+          {{- if $i }}, {{ end }}{{ $image -}}
+        {{- end }}
+  interval: 1m0s
+  update:
+    strategy: Setters

--- a/flux/overlays/scaleway-parca-demo/kustomization.yaml
+++ b/flux/overlays/scaleway-parca-demo/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - imagepolicies.yaml
 - imagerepositories.yaml
 - imageupdateautomation.yaml
+- ssh-credentials-secret.yaml

--- a/flux/overlays/scaleway-parca-demo/kustomization.yaml
+++ b/flux/overlays/scaleway-parca-demo/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+
+resources:
+- ../../base
+- gitrepository.yaml
+- imagepolicies.yaml
+- imagerepositories.yaml
+- imageupdateautomation.yaml

--- a/flux/overlays/scaleway-parca-demo/ssh-credentials-secret.yaml
+++ b/flux/overlays/scaleway-parca-demo/ssh-credentials-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flux-ssh-credentials
+stringData:
+  # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+  known_hosts: |
+    github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+    github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+    github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=

--- a/parca/README.md
+++ b/parca/README.md
@@ -2,5 +2,5 @@
 
 See:
 
-* github.com/parca-dev/parca
-* github.com/parca-dev/parca-agent
+* https://github.com/parca-dev/parca
+* https://github.com/parca-dev/parca-agent

--- a/parca/lib/parca-agent.libsonnet
+++ b/parca/lib/parca-agent.libsonnet
@@ -1,8 +1,9 @@
 local pa = import 'github.com/parca-dev/parca-agent/deploy/lib/parca-agent/parca-agent.libsonnet';
+local versions = std.parseYaml(importstr './versions.yaml');
 
 local defaults = {
   namespace: 'parca',
-  version: 'v0.19.0-62-ga25185e',
+  version: versions.parcaAgent,
   image: 'ghcr.io/parca-dev/parca-agent:' + self.version,
   stores: ['parca.%s.svc.cluster.local:7070' % self.namespace],
   insecure: true,

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -1,8 +1,9 @@
 local p = import 'github.com/parca-dev/parca/deploy/lib/parca/parca.libsonnet';
+local versions = std.parseYaml(importstr './versions.yaml');
 
 local defaults = {
   namespace: 'parca',
-  version: 'main-d88b069f',
+  version: versions.parca,
   image: 'ghcr.io/parca-dev/parca:' + self.version,
   replicas: 1,
   ingress: {

--- a/parca/lib/versions.yaml
+++ b/parca/lib/versions.yaml
@@ -1,0 +1,4 @@
+# Maintained by Flux
+# See flux-image-update/overlays/scaleway-parca-demo/ for the configuration
+parca: main-d88b069f # {"$imagepolicy": "flux-system:parca:tag"}
+parcaAgent: v0.19.0-62-ga25185e # {"$imagepolicy": "flux-system:parca-agent:tag"}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,12 @@
   "extends": ["github>parca-dev/.github"],
   "packageRules": [
     {
+      "description": "Group Flux CD packages and update them even if they are pre-releases",
+      "matchPackagePatterns": ["^fluxcd/.+"],
+      "ignoreUnstable": false,
+      "groupName": "fluxcd"
+    },
+    {
       "description": "Highlight build dependencies updates",
       "matchManagers": [
         "helmv3",
@@ -15,7 +21,10 @@
     },
     {
       "description": "Highlight build dependencies updates",
-      "matchPaths": [".+\\.(?:j|lib)sonnet"],
+      "matchPaths": [
+        "(^|/)kustomization.yaml$",
+        ".+\\.(?:j|lib)sonnet"
+      ],
       "automerge": false,
       "semanticCommitType": "build"
     }
@@ -30,6 +39,14 @@
       "matchStrings": [
         "// renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s+.+:\\s'(?<currentValue>.+?)',\\s"
       ]
+    },
+    {
+      "description": "Pin Kustomize bases digests - https://github.com/renovatebot/renovate/issues/7915",
+      "fileMatch": ["(^|/)kustomization.yaml$"],
+      "matchStrings": [
+          "- github\\.com\\/(?<depName>[^/]+?\\/[^/]*?)\\/.*\\?ref=(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
This configures the Flux v2 services responsible for image updates in order to automate the release of the `parca` and `parca-agent` container images to [demo.parca.dev](https://demo.parca.dev) from their respective `main` branches.

See also: [fluxcd.io/flux/guides/image-update](https://fluxcd.io/flux/guides/image-update/)

Currently running in the cluster with reconciliation suspended.