### PR TITLE
feat: add Argo CD

### DIFF
--- a/.schemas/Makefile
+++ b/.schemas/Makefile
@@ -5,6 +5,9 @@ KUBECONFORM_VERSION := v0.6.1
 
 CRDS := \
 	https://github.com/jetstack/cert-manager/releases/download/v1.11.2/cert-manager.crds.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.1/manifests/crds/applicationset-crd.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.1/manifests/crds/application-crd.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.1/manifests/crds/appproject-crd.yaml \
 	https://raw.githubusercontent.com/fluxcd/image-automation-controller/v0.33.1/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml \
 	https://raw.githubusercontent.com/fluxcd/image-reflector-controller/v0.27.2/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml \
 	https://raw.githubusercontent.com/fluxcd/image-reflector-controller/v0.27.2/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml \

--- a/.schemas/application-argoproj-v1alpha1.json
+++ b/.schemas/application-argoproj-v1alpha1.json
@@ -1,0 +1,5039 @@
+{
+  "description": "Application is a definition of Application resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "operation": {
+      "description": "Operation contains information about a requested or running operation",
+      "properties": {
+        "info": {
+          "description": "Info is a list of informational items for this operation",
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "initiatedBy": {
+          "description": "InitiatedBy contains information about who initiated the operations",
+          "properties": {
+            "automated": {
+              "description": "Automated is set to true if operation was initiated automatically by the application controller.",
+              "type": "boolean"
+            },
+            "username": {
+              "description": "Username contains the name of a user who started operation",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry": {
+          "description": "Retry controls the strategy to apply if a sync fails",
+          "properties": {
+            "backoff": {
+              "description": "Backoff controls how to backoff on subsequent retries of failed syncs",
+              "properties": {
+                "duration": {
+                  "description": "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
+                  "type": "string"
+                },
+                "factor": {
+                  "description": "Factor is a factor to multiply the base duration after each failed retry",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "maxDuration": {
+                  "description": "MaxDuration is the maximum amount of time allowed for the backoff strategy",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "limit": {
+              "description": "Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sync": {
+          "description": "Sync contains parameters for the operation",
+          "properties": {
+            "dryRun": {
+              "description": "DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync",
+              "type": "boolean"
+            },
+            "manifests": {
+              "description": "Manifests is an optional field that overrides sync source with a local directory for development",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "prune": {
+              "description": "Prune specifies to delete resources from the cluster that are no longer tracked in git",
+              "type": "boolean"
+            },
+            "resources": {
+              "description": "Resources describes which resources shall be part of the sync",
+              "items": {
+                "description": "SyncOperationResource contains resources to sync.",
+                "properties": {
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "revision": {
+              "description": "Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.",
+              "type": "string"
+            },
+            "revisions": {
+              "description": "Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to If omitted, will use the revision specified in app spec.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "source": {
+              "description": "Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation",
+              "properties": {
+                "chart": {
+                  "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                  "type": "string"
+                },
+                "directory": {
+                  "description": "Directory holds path/directory specific options",
+                  "properties": {
+                    "exclude": {
+                      "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                      "type": "string"
+                    },
+                    "include": {
+                      "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                      "type": "string"
+                    },
+                    "jsonnet": {
+                      "description": "Jsonnet holds options specific to Jsonnet",
+                      "properties": {
+                        "extVars": {
+                          "description": "ExtVars is a list of Jsonnet External Variables",
+                          "items": {
+                            "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                            "properties": {
+                              "code": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "libs": {
+                          "description": "Additional library search dirs",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "tlas": {
+                          "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                          "items": {
+                            "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                            "properties": {
+                              "code": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "recurse": {
+                      "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "helm": {
+                  "description": "Helm holds helm specific options",
+                  "properties": {
+                    "fileParameters": {
+                      "description": "FileParameters are file parameters to the helm template",
+                      "items": {
+                        "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the Helm parameter",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the file containing the values for the Helm parameter",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ignoreMissingValueFiles": {
+                      "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                      "type": "boolean"
+                    },
+                    "parameters": {
+                      "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                      "items": {
+                        "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                        "properties": {
+                          "forceString": {
+                            "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Name is the name of the Helm parameter",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value for the Helm parameter",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "passCredentials": {
+                      "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                      "type": "boolean"
+                    },
+                    "releaseName": {
+                      "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                      "type": "string"
+                    },
+                    "skipCrds": {
+                      "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                      "type": "boolean"
+                    },
+                    "valueFiles": {
+                      "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "values": {
+                      "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version is the Helm version to use for templating (\"3\")",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kustomize": {
+                  "description": "Kustomize holds kustomize specific options",
+                  "properties": {
+                    "commonAnnotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                      "type": "object"
+                    },
+                    "commonAnnotationsEnvsubst": {
+                      "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                      "type": "boolean"
+                    },
+                    "commonLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                      "type": "object"
+                    },
+                    "forceCommonAnnotations": {
+                      "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                      "type": "boolean"
+                    },
+                    "forceCommonLabels": {
+                      "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                      "type": "boolean"
+                    },
+                    "images": {
+                      "description": "Images is a list of Kustomize image override specifications",
+                      "items": {
+                        "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "namePrefix": {
+                      "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                      "type": "string"
+                    },
+                    "nameSuffix": {
+                      "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                      "type": "string"
+                    },
+                    "replicas": {
+                      "description": "Replicas is a list of Kustomize Replicas override specifications",
+                      "items": {
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number of replicas",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "name": {
+                            "description": "Name of Deployment or StatefulSet",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "count",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "description": "Version controls which version of Kustomize to use for rendering manifests",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "path": {
+                  "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                  "type": "string"
+                },
+                "plugin": {
+                  "description": "Plugin holds config management plugin specific options",
+                  "properties": {
+                    "env": {
+                      "description": "Env is a list of environment variable entries",
+                      "items": {
+                        "description": "EnvEntry represents an entry in the application's environment",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the variable, usually expressed in uppercase",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of the variable",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "parameters": {
+                      "items": {
+                        "properties": {
+                          "array": {
+                            "description": "Array is the value of an array type parameter.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "map": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map is the value of a map type parameter.",
+                            "type": "object"
+                          },
+                          "name": {
+                            "description": "Name is the name identifying a parameter.",
+                            "type": "string"
+                          },
+                          "string": {
+                            "description": "String_ is the value of a string type parameter.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ref": {
+                  "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                  "type": "string"
+                },
+                "repoURL": {
+                  "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                  "type": "string"
+                },
+                "targetRevision": {
+                  "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "repoURL"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sources": {
+              "description": "Sources overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation",
+              "items": {
+                "description": "ApplicationSource contains all required information about the source of an application",
+                "properties": {
+                  "chart": {
+                    "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                    "type": "string"
+                  },
+                  "directory": {
+                    "description": "Directory holds path/directory specific options",
+                    "properties": {
+                      "exclude": {
+                        "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                        "type": "string"
+                      },
+                      "include": {
+                        "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                        "type": "string"
+                      },
+                      "jsonnet": {
+                        "description": "Jsonnet holds options specific to Jsonnet",
+                        "properties": {
+                          "extVars": {
+                            "description": "ExtVars is a list of Jsonnet External Variables",
+                            "items": {
+                              "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                              "properties": {
+                                "code": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "libs": {
+                            "description": "Additional library search dirs",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tlas": {
+                            "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                            "items": {
+                              "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                              "properties": {
+                                "code": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "recurse": {
+                        "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "helm": {
+                    "description": "Helm holds helm specific options",
+                    "properties": {
+                      "fileParameters": {
+                        "description": "FileParameters are file parameters to the helm template",
+                        "items": {
+                          "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the Helm parameter",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "Path is the path to the file containing the values for the Helm parameter",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "ignoreMissingValueFiles": {
+                        "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                        "type": "boolean"
+                      },
+                      "parameters": {
+                        "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                        "items": {
+                          "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                          "properties": {
+                            "forceString": {
+                              "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "Name is the name of the Helm parameter",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value for the Helm parameter",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "passCredentials": {
+                        "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                        "type": "boolean"
+                      },
+                      "releaseName": {
+                        "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                        "type": "string"
+                      },
+                      "skipCrds": {
+                        "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                        "type": "boolean"
+                      },
+                      "valueFiles": {
+                        "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "values": {
+                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version is the Helm version to use for templating (\"3\")",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kustomize": {
+                    "description": "Kustomize holds kustomize specific options",
+                    "properties": {
+                      "commonAnnotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                        "type": "object"
+                      },
+                      "commonAnnotationsEnvsubst": {
+                        "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                        "type": "boolean"
+                      },
+                      "commonLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                        "type": "object"
+                      },
+                      "forceCommonAnnotations": {
+                        "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                        "type": "boolean"
+                      },
+                      "forceCommonLabels": {
+                        "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                        "type": "boolean"
+                      },
+                      "images": {
+                        "description": "Images is a list of Kustomize image override specifications",
+                        "items": {
+                          "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namePrefix": {
+                        "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                        "type": "string"
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is a list of Kustomize Replicas override specifications",
+                        "items": {
+                          "properties": {
+                            "count": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number of replicas",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "name": {
+                              "description": "Name of Deployment or StatefulSet",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "version": {
+                        "description": "Version controls which version of Kustomize to use for rendering manifests",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                    "type": "string"
+                  },
+                  "plugin": {
+                    "description": "Plugin holds config management plugin specific options",
+                    "properties": {
+                      "env": {
+                        "description": "Env is a list of environment variable entries",
+                        "items": {
+                          "description": "EnvEntry represents an entry in the application's environment",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the variable, usually expressed in uppercase",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value of the variable",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "parameters": {
+                        "items": {
+                          "properties": {
+                            "array": {
+                              "description": "Array is the value of an array type parameter.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "map": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Map is the value of a map type parameter.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the name identifying a parameter.",
+                              "type": "string"
+                            },
+                            "string": {
+                              "description": "String_ is the value of a string type parameter.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ref": {
+                    "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                    "type": "string"
+                  },
+                  "repoURL": {
+                    "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                    "type": "string"
+                  },
+                  "targetRevision": {
+                    "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repoURL"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "syncOptions": {
+              "description": "SyncOptions provide per-sync sync-options, e.g. Validate=false",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "syncStrategy": {
+              "description": "SyncStrategy describes how to perform the sync",
+              "properties": {
+                "apply": {
+                  "description": "Apply will perform a `kubectl apply` to perform the sync.",
+                  "properties": {
+                    "force": {
+                      "description": "Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "hook": {
+                  "description": "Hook will submit any referenced resources to perform the sync. This is the default strategy",
+                  "properties": {
+                    "force": {
+                      "description": "Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.",
+      "properties": {
+        "destination": {
+          "description": "Destination is a reference to the target Kubernetes server and namespace",
+          "properties": {
+            "name": {
+              "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace",
+              "type": "string"
+            },
+            "server": {
+              "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ignoreDifferences": {
+          "description": "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison",
+          "items": {
+            "description": "ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "jqPathExpressions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "jsonPointers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "managedFieldsManagers": {
+                "description": "ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the desired state defined in the SCM and won't be displayed in diffs",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "info": {
+          "description": "Info contains a list of information (URLs, email addresses, and plain text) that relates to the application",
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "project": {
+          "description": "Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.",
+          "type": "string"
+        },
+        "revisionHistoryLimit": {
+          "description": "RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "source": {
+          "description": "Source is a reference to the location of the application's manifests or chart",
+          "properties": {
+            "chart": {
+              "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+              "type": "string"
+            },
+            "directory": {
+              "description": "Directory holds path/directory specific options",
+              "properties": {
+                "exclude": {
+                  "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                  "type": "string"
+                },
+                "include": {
+                  "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                  "type": "string"
+                },
+                "jsonnet": {
+                  "description": "Jsonnet holds options specific to Jsonnet",
+                  "properties": {
+                    "extVars": {
+                      "description": "ExtVars is a list of Jsonnet External Variables",
+                      "items": {
+                        "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                        "properties": {
+                          "code": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "libs": {
+                      "description": "Additional library search dirs",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "tlas": {
+                      "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                      "items": {
+                        "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                        "properties": {
+                          "code": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "recurse": {
+                  "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "helm": {
+              "description": "Helm holds helm specific options",
+              "properties": {
+                "fileParameters": {
+                  "description": "FileParameters are file parameters to the helm template",
+                  "items": {
+                    "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the Helm parameter",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the file containing the values for the Helm parameter",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ignoreMissingValueFiles": {
+                  "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                  "type": "boolean"
+                },
+                "parameters": {
+                  "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                  "items": {
+                    "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                    "properties": {
+                      "forceString": {
+                        "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name is the name of the Helm parameter",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value for the Helm parameter",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "passCredentials": {
+                  "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                  "type": "boolean"
+                },
+                "releaseName": {
+                  "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                  "type": "string"
+                },
+                "skipCrds": {
+                  "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                  "type": "boolean"
+                },
+                "valueFiles": {
+                  "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "values": {
+                  "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version is the Helm version to use for templating (\"3\")",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kustomize": {
+              "description": "Kustomize holds kustomize specific options",
+              "properties": {
+                "commonAnnotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                  "type": "object"
+                },
+                "commonAnnotationsEnvsubst": {
+                  "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                  "type": "boolean"
+                },
+                "commonLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                  "type": "object"
+                },
+                "forceCommonAnnotations": {
+                  "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                  "type": "boolean"
+                },
+                "forceCommonLabels": {
+                  "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                  "type": "boolean"
+                },
+                "images": {
+                  "description": "Images is a list of Kustomize image override specifications",
+                  "items": {
+                    "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "namePrefix": {
+                  "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                  "type": "string"
+                },
+                "nameSuffix": {
+                  "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                  "type": "string"
+                },
+                "replicas": {
+                  "description": "Replicas is a list of Kustomize Replicas override specifications",
+                  "items": {
+                    "properties": {
+                      "count": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number of replicas",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "name": {
+                        "description": "Name of Deployment or StatefulSet",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "count",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "version": {
+                  "description": "Version controls which version of Kustomize to use for rendering manifests",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+              "type": "string"
+            },
+            "plugin": {
+              "description": "Plugin holds config management plugin specific options",
+              "properties": {
+                "env": {
+                  "description": "Env is a list of environment variable entries",
+                  "items": {
+                    "description": "EnvEntry represents an entry in the application's environment",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the variable, usually expressed in uppercase",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value of the variable",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "parameters": {
+                  "items": {
+                    "properties": {
+                      "array": {
+                        "description": "Array is the value of an array type parameter.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "map": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Map is the value of a map type parameter.",
+                        "type": "object"
+                      },
+                      "name": {
+                        "description": "Name is the name identifying a parameter.",
+                        "type": "string"
+                      },
+                      "string": {
+                        "description": "String_ is the value of a string type parameter.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ref": {
+              "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+              "type": "string"
+            },
+            "repoURL": {
+              "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+              "type": "string"
+            },
+            "targetRevision": {
+              "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repoURL"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sources": {
+          "description": "Sources is a reference to the location of the application's manifests or chart",
+          "items": {
+            "description": "ApplicationSource contains all required information about the source of an application",
+            "properties": {
+              "chart": {
+                "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                "type": "string"
+              },
+              "directory": {
+                "description": "Directory holds path/directory specific options",
+                "properties": {
+                  "exclude": {
+                    "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                    "type": "string"
+                  },
+                  "include": {
+                    "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                    "type": "string"
+                  },
+                  "jsonnet": {
+                    "description": "Jsonnet holds options specific to Jsonnet",
+                    "properties": {
+                      "extVars": {
+                        "description": "ExtVars is a list of Jsonnet External Variables",
+                        "items": {
+                          "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                          "properties": {
+                            "code": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "libs": {
+                        "description": "Additional library search dirs",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "tlas": {
+                        "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                        "items": {
+                          "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                          "properties": {
+                            "code": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "recurse": {
+                    "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "helm": {
+                "description": "Helm holds helm specific options",
+                "properties": {
+                  "fileParameters": {
+                    "description": "FileParameters are file parameters to the helm template",
+                    "items": {
+                      "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the Helm parameter",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path is the path to the file containing the values for the Helm parameter",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "ignoreMissingValueFiles": {
+                    "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                    "type": "boolean"
+                  },
+                  "parameters": {
+                    "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                    "items": {
+                      "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                      "properties": {
+                        "forceString": {
+                          "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "description": "Name is the name of the Helm parameter",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the value for the Helm parameter",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "passCredentials": {
+                    "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                    "type": "boolean"
+                  },
+                  "releaseName": {
+                    "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                    "type": "string"
+                  },
+                  "skipCrds": {
+                    "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                    "type": "boolean"
+                  },
+                  "valueFiles": {
+                    "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "values": {
+                    "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "Version is the Helm version to use for templating (\"3\")",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kustomize": {
+                "description": "Kustomize holds kustomize specific options",
+                "properties": {
+                  "commonAnnotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                    "type": "object"
+                  },
+                  "commonAnnotationsEnvsubst": {
+                    "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                    "type": "boolean"
+                  },
+                  "commonLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                    "type": "object"
+                  },
+                  "forceCommonAnnotations": {
+                    "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                    "type": "boolean"
+                  },
+                  "forceCommonLabels": {
+                    "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                    "type": "boolean"
+                  },
+                  "images": {
+                    "description": "Images is a list of Kustomize image override specifications",
+                    "items": {
+                      "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "namePrefix": {
+                    "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                    "type": "string"
+                  },
+                  "nameSuffix": {
+                    "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                    "type": "string"
+                  },
+                  "replicas": {
+                    "description": "Replicas is a list of Kustomize Replicas override specifications",
+                    "items": {
+                      "properties": {
+                        "count": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number of replicas",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "name": {
+                          "description": "Name of Deployment or StatefulSet",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "version": {
+                    "description": "Version controls which version of Kustomize to use for rendering manifests",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "path": {
+                "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                "type": "string"
+              },
+              "plugin": {
+                "description": "Plugin holds config management plugin specific options",
+                "properties": {
+                  "env": {
+                    "description": "Env is a list of environment variable entries",
+                    "items": {
+                      "description": "EnvEntry represents an entry in the application's environment",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the variable, usually expressed in uppercase",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the value of the variable",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "items": {
+                      "properties": {
+                        "array": {
+                          "description": "Array is the value of an array type parameter.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "map": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Map is the value of a map type parameter.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the name identifying a parameter.",
+                          "type": "string"
+                        },
+                        "string": {
+                          "description": "String_ is the value of a string type parameter.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ref": {
+                "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                "type": "string"
+              },
+              "repoURL": {
+                "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                "type": "string"
+              },
+              "targetRevision": {
+                "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repoURL"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "syncPolicy": {
+          "description": "SyncPolicy controls when and how a sync will be performed",
+          "properties": {
+            "automated": {
+              "description": "Automated will keep an application synced to the target revision",
+              "properties": {
+                "allowEmpty": {
+                  "description": "AllowEmpty allows apps have zero live resources (default: false)",
+                  "type": "boolean"
+                },
+                "prune": {
+                  "description": "Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)",
+                  "type": "boolean"
+                },
+                "selfHeal": {
+                  "description": "SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "managedNamespaceMetadata": {
+              "description": "ManagedNamespaceMetadata controls metadata in the given namespace (if CreateNamespace=true)",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "retry": {
+              "description": "Retry controls failed sync retry behavior",
+              "properties": {
+                "backoff": {
+                  "description": "Backoff controls how to backoff on subsequent retries of failed syncs",
+                  "properties": {
+                    "duration": {
+                      "description": "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
+                      "type": "string"
+                    },
+                    "factor": {
+                      "description": "Factor is a factor to multiply the base duration after each failed retry",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "maxDuration": {
+                      "description": "MaxDuration is the maximum amount of time allowed for the backoff strategy",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "limit": {
+                  "description": "Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.",
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "syncOptions": {
+              "description": "Options allow you to specify whole app sync-options",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "destination",
+        "project"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ApplicationStatus contains status information for the application",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is a list of currently observed application conditions",
+          "items": {
+            "description": "ApplicationCondition contains details about an application condition, which is usally an error or warning",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the time the condition was last observed",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "Message contains human-readable message indicating details about condition",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is an application condition type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "health": {
+          "description": "Health contains information about the application's current health status",
+          "properties": {
+            "message": {
+              "description": "Message is a human-readable informational message describing the health status",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status holds the status code of the application or resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "history": {
+          "description": "History contains information about the application's sync history",
+          "items": {
+            "description": "RevisionHistory contains history information about a previous sync",
+            "properties": {
+              "deployStartedAt": {
+                "description": "DeployStartedAt holds the time the sync operation started",
+                "format": "date-time",
+                "type": "string"
+              },
+              "deployedAt": {
+                "description": "DeployedAt holds the time the sync operation completed",
+                "format": "date-time",
+                "type": "string"
+              },
+              "id": {
+                "description": "ID is an auto incrementing identifier of the RevisionHistory",
+                "format": "int64",
+                "type": "integer"
+              },
+              "revision": {
+                "description": "Revision holds the revision the sync was performed against",
+                "type": "string"
+              },
+              "revisions": {
+                "description": "Revisions holds the revision of each source in sources field the sync was performed against",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "source": {
+                "description": "Source is a reference to the application source used for the sync operation",
+                "properties": {
+                  "chart": {
+                    "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                    "type": "string"
+                  },
+                  "directory": {
+                    "description": "Directory holds path/directory specific options",
+                    "properties": {
+                      "exclude": {
+                        "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                        "type": "string"
+                      },
+                      "include": {
+                        "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                        "type": "string"
+                      },
+                      "jsonnet": {
+                        "description": "Jsonnet holds options specific to Jsonnet",
+                        "properties": {
+                          "extVars": {
+                            "description": "ExtVars is a list of Jsonnet External Variables",
+                            "items": {
+                              "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                              "properties": {
+                                "code": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "libs": {
+                            "description": "Additional library search dirs",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tlas": {
+                            "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                            "items": {
+                              "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                              "properties": {
+                                "code": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "recurse": {
+                        "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "helm": {
+                    "description": "Helm holds helm specific options",
+                    "properties": {
+                      "fileParameters": {
+                        "description": "FileParameters are file parameters to the helm template",
+                        "items": {
+                          "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the Helm parameter",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "Path is the path to the file containing the values for the Helm parameter",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "ignoreMissingValueFiles": {
+                        "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                        "type": "boolean"
+                      },
+                      "parameters": {
+                        "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                        "items": {
+                          "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                          "properties": {
+                            "forceString": {
+                              "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "Name is the name of the Helm parameter",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value for the Helm parameter",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "passCredentials": {
+                        "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                        "type": "boolean"
+                      },
+                      "releaseName": {
+                        "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                        "type": "string"
+                      },
+                      "skipCrds": {
+                        "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                        "type": "boolean"
+                      },
+                      "valueFiles": {
+                        "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "values": {
+                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version is the Helm version to use for templating (\"3\")",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kustomize": {
+                    "description": "Kustomize holds kustomize specific options",
+                    "properties": {
+                      "commonAnnotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                        "type": "object"
+                      },
+                      "commonAnnotationsEnvsubst": {
+                        "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                        "type": "boolean"
+                      },
+                      "commonLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                        "type": "object"
+                      },
+                      "forceCommonAnnotations": {
+                        "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                        "type": "boolean"
+                      },
+                      "forceCommonLabels": {
+                        "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                        "type": "boolean"
+                      },
+                      "images": {
+                        "description": "Images is a list of Kustomize image override specifications",
+                        "items": {
+                          "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namePrefix": {
+                        "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                        "type": "string"
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is a list of Kustomize Replicas override specifications",
+                        "items": {
+                          "properties": {
+                            "count": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number of replicas",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "name": {
+                              "description": "Name of Deployment or StatefulSet",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "version": {
+                        "description": "Version controls which version of Kustomize to use for rendering manifests",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                    "type": "string"
+                  },
+                  "plugin": {
+                    "description": "Plugin holds config management plugin specific options",
+                    "properties": {
+                      "env": {
+                        "description": "Env is a list of environment variable entries",
+                        "items": {
+                          "description": "EnvEntry represents an entry in the application's environment",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the variable, usually expressed in uppercase",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value of the variable",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "parameters": {
+                        "items": {
+                          "properties": {
+                            "array": {
+                              "description": "Array is the value of an array type parameter.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "map": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Map is the value of a map type parameter.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the name identifying a parameter.",
+                              "type": "string"
+                            },
+                            "string": {
+                              "description": "String_ is the value of a string type parameter.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ref": {
+                    "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                    "type": "string"
+                  },
+                  "repoURL": {
+                    "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                    "type": "string"
+                  },
+                  "targetRevision": {
+                    "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repoURL"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "sources": {
+                "description": "Sources is a reference to the application sources used for the sync operation",
+                "items": {
+                  "description": "ApplicationSource contains all required information about the source of an application",
+                  "properties": {
+                    "chart": {
+                      "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                      "type": "string"
+                    },
+                    "directory": {
+                      "description": "Directory holds path/directory specific options",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                          "type": "string"
+                        },
+                        "include": {
+                          "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                          "type": "string"
+                        },
+                        "jsonnet": {
+                          "description": "Jsonnet holds options specific to Jsonnet",
+                          "properties": {
+                            "extVars": {
+                              "description": "ExtVars is a list of Jsonnet External Variables",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "libs": {
+                              "description": "Additional library search dirs",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tlas": {
+                              "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurse": {
+                          "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "helm": {
+                      "description": "Helm holds helm specific options",
+                      "properties": {
+                        "fileParameters": {
+                          "description": "FileParameters are file parameters to the helm template",
+                          "items": {
+                            "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path is the path to the file containing the values for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ignoreMissingValueFiles": {
+                          "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                          "type": "boolean"
+                        },
+                        "parameters": {
+                          "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                          "items": {
+                            "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "forceString": {
+                                "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "passCredentials": {
+                          "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                          "type": "boolean"
+                        },
+                        "releaseName": {
+                          "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                          "type": "string"
+                        },
+                        "skipCrds": {
+                          "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                          "type": "boolean"
+                        },
+                        "valueFiles": {
+                          "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "values": {
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version is the Helm version to use for templating (\"3\")",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kustomize": {
+                      "description": "Kustomize holds kustomize specific options",
+                      "properties": {
+                        "commonAnnotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
+                        },
+                        "commonLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "forceCommonAnnotations": {
+                          "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "forceCommonLabels": {
+                          "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "images": {
+                          "description": "Images is a list of Kustomize image override specifications",
+                          "items": {
+                            "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "namePrefix": {
+                          "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "nameSuffix": {
+                          "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "version": {
+                          "description": "Version controls which version of Kustomize to use for rendering manifests",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                      "type": "string"
+                    },
+                    "plugin": {
+                      "description": "Plugin holds config management plugin specific options",
+                      "properties": {
+                        "env": {
+                          "description": "Env is a list of environment variable entries",
+                          "items": {
+                            "description": "EnvEntry represents an entry in the application's environment",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the variable, usually expressed in uppercase",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of the variable",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "array": {
+                                "description": "Array is the value of an array type parameter.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "map": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Map is the value of a map type parameter.",
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the name identifying a parameter.",
+                                "type": "string"
+                              },
+                              "string": {
+                                "description": "String_ is the value of a string type parameter.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ref": {
+                      "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                      "type": "string"
+                    },
+                    "repoURL": {
+                      "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                      "type": "string"
+                    },
+                    "targetRevision": {
+                      "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "repoURL"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "deployedAt",
+              "id"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedAt": {
+          "description": "ObservedAt indicates when the application state was updated without querying latest git state Deprecated: controller no longer updates ObservedAt field",
+          "format": "date-time",
+          "type": "string"
+        },
+        "operationState": {
+          "description": "OperationState contains information about any ongoing operations, such as a sync",
+          "properties": {
+            "finishedAt": {
+              "description": "FinishedAt contains time of operation completion",
+              "format": "date-time",
+              "type": "string"
+            },
+            "message": {
+              "description": "Message holds any pertinent messages when attempting to perform operation (typically errors).",
+              "type": "string"
+            },
+            "operation": {
+              "description": "Operation is the original requested operation",
+              "properties": {
+                "info": {
+                  "description": "Info is a list of informational items for this operation",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initiatedBy": {
+                  "description": "InitiatedBy contains information about who initiated the operations",
+                  "properties": {
+                    "automated": {
+                      "description": "Automated is set to true if operation was initiated automatically by the application controller.",
+                      "type": "boolean"
+                    },
+                    "username": {
+                      "description": "Username contains the name of a user who started operation",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "retry": {
+                  "description": "Retry controls the strategy to apply if a sync fails",
+                  "properties": {
+                    "backoff": {
+                      "description": "Backoff controls how to backoff on subsequent retries of failed syncs",
+                      "properties": {
+                        "duration": {
+                          "description": "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
+                          "type": "string"
+                        },
+                        "factor": {
+                          "description": "Factor is a factor to multiply the base duration after each failed retry",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "maxDuration": {
+                          "description": "MaxDuration is the maximum amount of time allowed for the backoff strategy",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "limit": {
+                      "description": "Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sync": {
+                  "description": "Sync contains parameters for the operation",
+                  "properties": {
+                    "dryRun": {
+                      "description": "DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync",
+                      "type": "boolean"
+                    },
+                    "manifests": {
+                      "description": "Manifests is an optional field that overrides sync source with a local directory for development",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "prune": {
+                      "description": "Prune specifies to delete resources from the cluster that are no longer tracked in git",
+                      "type": "boolean"
+                    },
+                    "resources": {
+                      "description": "Resources describes which resources shall be part of the sync",
+                      "items": {
+                        "description": "SyncOperationResource contains resources to sync.",
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "revision": {
+                      "description": "Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.",
+                      "type": "string"
+                    },
+                    "revisions": {
+                      "description": "Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to If omitted, will use the revision specified in app spec.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "source": {
+                      "description": "Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation",
+                      "properties": {
+                        "chart": {
+                          "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                          "type": "string"
+                        },
+                        "directory": {
+                          "description": "Directory holds path/directory specific options",
+                          "properties": {
+                            "exclude": {
+                              "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                              "type": "string"
+                            },
+                            "include": {
+                              "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                              "type": "string"
+                            },
+                            "jsonnet": {
+                              "description": "Jsonnet holds options specific to Jsonnet",
+                              "properties": {
+                                "extVars": {
+                                  "description": "ExtVars is a list of Jsonnet External Variables",
+                                  "items": {
+                                    "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                    "properties": {
+                                      "code": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "libs": {
+                                  "description": "Additional library search dirs",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tlas": {
+                                  "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                                  "items": {
+                                    "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                    "properties": {
+                                      "code": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "recurse": {
+                              "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "helm": {
+                          "description": "Helm holds helm specific options",
+                          "properties": {
+                            "fileParameters": {
+                              "description": "FileParameters are file parameters to the helm template",
+                              "items": {
+                                "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the Helm parameter",
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "Path is the path to the file containing the values for the Helm parameter",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "ignoreMissingValueFiles": {
+                              "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                              "type": "boolean"
+                            },
+                            "parameters": {
+                              "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                              "items": {
+                                "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                                "properties": {
+                                  "forceString": {
+                                    "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the Helm parameter",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the value for the Helm parameter",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "passCredentials": {
+                              "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                              "type": "boolean"
+                            },
+                            "releaseName": {
+                              "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                              "type": "string"
+                            },
+                            "skipCrds": {
+                              "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                              "type": "boolean"
+                            },
+                            "valueFiles": {
+                              "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "values": {
+                              "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                              "type": "string"
+                            },
+                            "version": {
+                              "description": "Version is the Helm version to use for templating (\"3\")",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "kustomize": {
+                          "description": "Kustomize holds kustomize specific options",
+                          "properties": {
+                            "commonAnnotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                              "type": "object"
+                            },
+                            "commonAnnotationsEnvsubst": {
+                              "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                              "type": "boolean"
+                            },
+                            "commonLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                              "type": "object"
+                            },
+                            "forceCommonAnnotations": {
+                              "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                              "type": "boolean"
+                            },
+                            "forceCommonLabels": {
+                              "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                              "type": "boolean"
+                            },
+                            "images": {
+                              "description": "Images is a list of Kustomize image override specifications",
+                              "items": {
+                                "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namePrefix": {
+                              "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                              "type": "string"
+                            },
+                            "nameSuffix": {
+                              "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                              "type": "string"
+                            },
+                            "replicas": {
+                              "description": "Replicas is a list of Kustomize Replicas override specifications",
+                              "items": {
+                                "properties": {
+                                  "count": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "description": "Number of replicas",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "name": {
+                                    "description": "Name of Deployment or StatefulSet",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "count",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "version": {
+                              "description": "Version controls which version of Kustomize to use for rendering manifests",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                          "type": "string"
+                        },
+                        "plugin": {
+                          "description": "Plugin holds config management plugin specific options",
+                          "properties": {
+                            "env": {
+                              "description": "Env is a list of environment variable entries",
+                              "items": {
+                                "description": "EnvEntry represents an entry in the application's environment",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the variable, usually expressed in uppercase",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the value of the variable",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "parameters": {
+                              "items": {
+                                "properties": {
+                                  "array": {
+                                    "description": "Array is the value of an array type parameter.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "map": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Map is the value of a map type parameter.",
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name identifying a parameter.",
+                                    "type": "string"
+                                  },
+                                  "string": {
+                                    "description": "String_ is the value of a string type parameter.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "ref": {
+                          "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                          "type": "string"
+                        },
+                        "targetRevision": {
+                          "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "repoURL"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sources": {
+                      "description": "Sources overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation",
+                      "items": {
+                        "description": "ApplicationSource contains all required information about the source of an application",
+                        "properties": {
+                          "chart": {
+                            "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                            "type": "string"
+                          },
+                          "directory": {
+                            "description": "Directory holds path/directory specific options",
+                            "properties": {
+                              "exclude": {
+                                "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                                "type": "string"
+                              },
+                              "include": {
+                                "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                                "type": "string"
+                              },
+                              "jsonnet": {
+                                "description": "Jsonnet holds options specific to Jsonnet",
+                                "properties": {
+                                  "extVars": {
+                                    "description": "ExtVars is a list of Jsonnet External Variables",
+                                    "items": {
+                                      "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                      "properties": {
+                                        "code": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "libs": {
+                                    "description": "Additional library search dirs",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tlas": {
+                                    "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                                    "items": {
+                                      "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                      "properties": {
+                                        "code": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurse": {
+                                "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "helm": {
+                            "description": "Helm holds helm specific options",
+                            "properties": {
+                              "fileParameters": {
+                                "description": "FileParameters are file parameters to the helm template",
+                                "items": {
+                                  "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the Helm parameter",
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "description": "Path is the path to the file containing the values for the Helm parameter",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "ignoreMissingValueFiles": {
+                                "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                                "type": "boolean"
+                              },
+                              "parameters": {
+                                "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                                "items": {
+                                  "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                                  "properties": {
+                                    "forceString": {
+                                      "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "description": "Name is the name of the Helm parameter",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value for the Helm parameter",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "passCredentials": {
+                                "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                                "type": "boolean"
+                              },
+                              "releaseName": {
+                                "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                                "type": "string"
+                              },
+                              "skipCrds": {
+                                "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                                "type": "boolean"
+                              },
+                              "valueFiles": {
+                                "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "values": {
+                                "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "Version is the Helm version to use for templating (\"3\")",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "kustomize": {
+                            "description": "Kustomize holds kustomize specific options",
+                            "properties": {
+                              "commonAnnotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                                "type": "object"
+                              },
+                              "commonAnnotationsEnvsubst": {
+                                "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                                "type": "boolean"
+                              },
+                              "commonLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                                "type": "object"
+                              },
+                              "forceCommonAnnotations": {
+                                "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                                "type": "boolean"
+                              },
+                              "forceCommonLabels": {
+                                "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                                "type": "boolean"
+                              },
+                              "images": {
+                                "description": "Images is a list of Kustomize image override specifications",
+                                "items": {
+                                  "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namePrefix": {
+                                "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                                "type": "string"
+                              },
+                              "nameSuffix": {
+                                "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                                "type": "string"
+                              },
+                              "replicas": {
+                                "description": "Replicas is a list of Kustomize Replicas override specifications",
+                                "items": {
+                                  "properties": {
+                                    "count": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "description": "Number of replicas",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "name": {
+                                      "description": "Name of Deployment or StatefulSet",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "count",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "version": {
+                                "description": "Version controls which version of Kustomize to use for rendering manifests",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                            "type": "string"
+                          },
+                          "plugin": {
+                            "description": "Plugin holds config management plugin specific options",
+                            "properties": {
+                              "env": {
+                                "description": "Env is a list of environment variable entries",
+                                "items": {
+                                  "description": "EnvEntry represents an entry in the application's environment",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the variable, usually expressed in uppercase",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of the variable",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "items": {
+                                  "properties": {
+                                    "array": {
+                                      "description": "Array is the value of an array type parameter.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "map": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "Map is the value of a map type parameter.",
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "description": "Name is the name identifying a parameter.",
+                                      "type": "string"
+                                    },
+                                    "string": {
+                                      "description": "String_ is the value of a string type parameter.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ref": {
+                            "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                            "type": "string"
+                          },
+                          "targetRevision": {
+                            "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "repoURL"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "syncOptions": {
+                      "description": "SyncOptions provide per-sync sync-options, e.g. Validate=false",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "syncStrategy": {
+                      "description": "SyncStrategy describes how to perform the sync",
+                      "properties": {
+                        "apply": {
+                          "description": "Apply will perform a `kubectl apply` to perform the sync.",
+                          "properties": {
+                            "force": {
+                              "description": "Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "hook": {
+                          "description": "Hook will submit any referenced resources to perform the sync. This is the default strategy",
+                          "properties": {
+                            "force": {
+                              "description": "Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "phase": {
+              "description": "Phase is the current phase of the operation",
+              "type": "string"
+            },
+            "retryCount": {
+              "description": "RetryCount contains time of operation retries",
+              "format": "int64",
+              "type": "integer"
+            },
+            "startedAt": {
+              "description": "StartedAt contains time of operation start",
+              "format": "date-time",
+              "type": "string"
+            },
+            "syncResult": {
+              "description": "SyncResult is the result of a Sync operation",
+              "properties": {
+                "resources": {
+                  "description": "Resources contains a list of sync result items for each individual resource in a sync operation",
+                  "items": {
+                    "description": "ResourceResult holds the operation result details of a specific resource",
+                    "properties": {
+                      "group": {
+                        "description": "Group specifies the API group of the resource",
+                        "type": "string"
+                      },
+                      "hookPhase": {
+                        "description": "HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.",
+                        "type": "string"
+                      },
+                      "hookType": {
+                        "description": "HookType specifies the type of the hook. Empty for non-hook resources",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind specifies the API kind of the resource",
+                        "type": "string"
+                      },
+                      "message": {
+                        "description": "Message contains an informational or error message for the last sync OR operation",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the name of the resource",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies the target namespace of the resource",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks",
+                        "type": "string"
+                      },
+                      "syncPhase": {
+                        "description": "SyncPhase indicates the particular phase of the sync that this result was acquired in",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version specifies the API version of the resource",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "group",
+                      "kind",
+                      "name",
+                      "namespace",
+                      "version"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "revision": {
+                  "description": "Revision holds the revision this sync operation was performed to",
+                  "type": "string"
+                },
+                "revisions": {
+                  "description": "Revisions holds the revision this sync operation was performed for respective indexed source in sources field",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "source": {
+                  "description": "Source records the application source information of the sync, used for comparing auto-sync",
+                  "properties": {
+                    "chart": {
+                      "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                      "type": "string"
+                    },
+                    "directory": {
+                      "description": "Directory holds path/directory specific options",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                          "type": "string"
+                        },
+                        "include": {
+                          "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                          "type": "string"
+                        },
+                        "jsonnet": {
+                          "description": "Jsonnet holds options specific to Jsonnet",
+                          "properties": {
+                            "extVars": {
+                              "description": "ExtVars is a list of Jsonnet External Variables",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "libs": {
+                              "description": "Additional library search dirs",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tlas": {
+                              "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurse": {
+                          "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "helm": {
+                      "description": "Helm holds helm specific options",
+                      "properties": {
+                        "fileParameters": {
+                          "description": "FileParameters are file parameters to the helm template",
+                          "items": {
+                            "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path is the path to the file containing the values for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ignoreMissingValueFiles": {
+                          "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                          "type": "boolean"
+                        },
+                        "parameters": {
+                          "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                          "items": {
+                            "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "forceString": {
+                                "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "passCredentials": {
+                          "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                          "type": "boolean"
+                        },
+                        "releaseName": {
+                          "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                          "type": "string"
+                        },
+                        "skipCrds": {
+                          "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                          "type": "boolean"
+                        },
+                        "valueFiles": {
+                          "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "values": {
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version is the Helm version to use for templating (\"3\")",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kustomize": {
+                      "description": "Kustomize holds kustomize specific options",
+                      "properties": {
+                        "commonAnnotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
+                        },
+                        "commonLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "forceCommonAnnotations": {
+                          "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "forceCommonLabels": {
+                          "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "images": {
+                          "description": "Images is a list of Kustomize image override specifications",
+                          "items": {
+                            "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "namePrefix": {
+                          "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "nameSuffix": {
+                          "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "version": {
+                          "description": "Version controls which version of Kustomize to use for rendering manifests",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                      "type": "string"
+                    },
+                    "plugin": {
+                      "description": "Plugin holds config management plugin specific options",
+                      "properties": {
+                        "env": {
+                          "description": "Env is a list of environment variable entries",
+                          "items": {
+                            "description": "EnvEntry represents an entry in the application's environment",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the variable, usually expressed in uppercase",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of the variable",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "array": {
+                                "description": "Array is the value of an array type parameter.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "map": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Map is the value of a map type parameter.",
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the name identifying a parameter.",
+                                "type": "string"
+                              },
+                              "string": {
+                                "description": "String_ is the value of a string type parameter.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ref": {
+                      "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                      "type": "string"
+                    },
+                    "repoURL": {
+                      "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                      "type": "string"
+                    },
+                    "targetRevision": {
+                      "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "repoURL"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sources": {
+                  "description": "Source records the application source information of the sync, used for comparing auto-sync",
+                  "items": {
+                    "description": "ApplicationSource contains all required information about the source of an application",
+                    "properties": {
+                      "chart": {
+                        "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                        "type": "string"
+                      },
+                      "directory": {
+                        "description": "Directory holds path/directory specific options",
+                        "properties": {
+                          "exclude": {
+                            "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                            "type": "string"
+                          },
+                          "include": {
+                            "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                            "type": "string"
+                          },
+                          "jsonnet": {
+                            "description": "Jsonnet holds options specific to Jsonnet",
+                            "properties": {
+                              "extVars": {
+                                "description": "ExtVars is a list of Jsonnet External Variables",
+                                "items": {
+                                  "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "libs": {
+                                "description": "Additional library search dirs",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tlas": {
+                                "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                                "items": {
+                                  "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurse": {
+                            "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "helm": {
+                        "description": "Helm holds helm specific options",
+                        "properties": {
+                          "fileParameters": {
+                            "description": "FileParameters are file parameters to the helm template",
+                            "items": {
+                              "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of the Helm parameter",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "Path is the path to the file containing the values for the Helm parameter",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "ignoreMissingValueFiles": {
+                            "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                            "type": "boolean"
+                          },
+                          "parameters": {
+                            "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                            "items": {
+                              "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                              "properties": {
+                                "forceString": {
+                                  "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the Helm parameter",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value is the value for the Helm parameter",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "passCredentials": {
+                            "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                            "type": "boolean"
+                          },
+                          "releaseName": {
+                            "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                            "type": "string"
+                          },
+                          "skipCrds": {
+                            "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                            "type": "boolean"
+                          },
+                          "valueFiles": {
+                            "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "values": {
+                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version is the Helm version to use for templating (\"3\")",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "kustomize": {
+                        "description": "Kustomize holds kustomize specific options",
+                        "properties": {
+                          "commonAnnotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                            "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                            "type": "boolean"
+                          },
+                          "commonLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                            "type": "object"
+                          },
+                          "forceCommonAnnotations": {
+                            "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                            "type": "boolean"
+                          },
+                          "forceCommonLabels": {
+                            "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                            "type": "boolean"
+                          },
+                          "images": {
+                            "description": "Images is a list of Kustomize image override specifications",
+                            "items": {
+                              "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namePrefix": {
+                            "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                            "type": "string"
+                          },
+                          "nameSuffix": {
+                            "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "description": "Replicas is a list of Kustomize Replicas override specifications",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number of replicas",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "description": "Name of Deployment or StatefulSet",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "version": {
+                            "description": "Version controls which version of Kustomize to use for rendering manifests",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "path": {
+                        "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                        "type": "string"
+                      },
+                      "plugin": {
+                        "description": "Plugin holds config management plugin specific options",
+                        "properties": {
+                          "env": {
+                            "description": "Env is a list of environment variable entries",
+                            "items": {
+                              "description": "EnvEntry represents an entry in the application's environment",
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of the variable, usually expressed in uppercase",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value is the value of the variable",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "array": {
+                                  "description": "Array is the value of an array type parameter.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "map": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Map is the value of a map type parameter.",
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "description": "Name is the name identifying a parameter.",
+                                  "type": "string"
+                                },
+                                "string": {
+                                  "description": "String_ is the value of a string type parameter.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ref": {
+                        "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                        "type": "string"
+                      },
+                      "repoURL": {
+                        "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                        "type": "string"
+                      },
+                      "targetRevision": {
+                        "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repoURL"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "revision"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "operation",
+            "phase",
+            "startedAt"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "reconciledAt": {
+          "description": "ReconciledAt indicates when the application state was reconciled using the latest git version",
+          "format": "date-time",
+          "type": "string"
+        },
+        "resourceHealthSource": {
+          "description": "ResourceHealthSource indicates where the resource health status is stored: inline if not set or appTree",
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resources is a list of Kubernetes resources managed by this application",
+          "items": {
+            "description": "ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "health": {
+                "description": "HealthStatus contains information about the currently observed health state of an application or resource",
+                "properties": {
+                  "message": {
+                    "description": "Message is a human-readable informational message describing the health status",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "Status holds the status code of the application or resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "hook": {
+                "type": "boolean"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "requiresPruning": {
+                "type": "boolean"
+              },
+              "status": {
+                "description": "SyncStatusCode is a type which represents possible comparison results",
+                "type": "string"
+              },
+              "syncWave": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "sourceType": {
+          "description": "SourceType specifies the type of this application",
+          "type": "string"
+        },
+        "sourceTypes": {
+          "description": "SourceTypes specifies the type of the sources included in the application",
+          "items": {
+            "description": "ApplicationSourceType specifies the type of the application's source",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "description": "Summary contains a list of URLs and container images used by this application",
+          "properties": {
+            "externalURLs": {
+              "description": "ExternalURLs holds all external URLs of application child resources.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "images": {
+              "description": "Images holds all images of application child resources.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sync": {
+          "description": "Sync contains information about the application's current sync status",
+          "properties": {
+            "comparedTo": {
+              "description": "ComparedTo contains information about what has been compared",
+              "properties": {
+                "destination": {
+                  "description": "Destination is a reference to the application's destination used for comparison",
+                  "properties": {
+                    "name": {
+                      "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace",
+                      "type": "string"
+                    },
+                    "server": {
+                      "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "source": {
+                  "description": "Source is a reference to the application's source used for comparison",
+                  "properties": {
+                    "chart": {
+                      "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                      "type": "string"
+                    },
+                    "directory": {
+                      "description": "Directory holds path/directory specific options",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                          "type": "string"
+                        },
+                        "include": {
+                          "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                          "type": "string"
+                        },
+                        "jsonnet": {
+                          "description": "Jsonnet holds options specific to Jsonnet",
+                          "properties": {
+                            "extVars": {
+                              "description": "ExtVars is a list of Jsonnet External Variables",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "libs": {
+                              "description": "Additional library search dirs",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tlas": {
+                              "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                              "items": {
+                                "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurse": {
+                          "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "helm": {
+                      "description": "Helm holds helm specific options",
+                      "properties": {
+                        "fileParameters": {
+                          "description": "FileParameters are file parameters to the helm template",
+                          "items": {
+                            "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path is the path to the file containing the values for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ignoreMissingValueFiles": {
+                          "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                          "type": "boolean"
+                        },
+                        "parameters": {
+                          "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                          "items": {
+                            "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                            "properties": {
+                              "forceString": {
+                                "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Name is the name of the Helm parameter",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value for the Helm parameter",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "passCredentials": {
+                          "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                          "type": "boolean"
+                        },
+                        "releaseName": {
+                          "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                          "type": "string"
+                        },
+                        "skipCrds": {
+                          "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                          "type": "boolean"
+                        },
+                        "valueFiles": {
+                          "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "values": {
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version is the Helm version to use for templating (\"3\")",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kustomize": {
+                      "description": "Kustomize holds kustomize specific options",
+                      "properties": {
+                        "commonAnnotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
+                        },
+                        "commonLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                          "type": "object"
+                        },
+                        "forceCommonAnnotations": {
+                          "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "forceCommonLabels": {
+                          "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                          "type": "boolean"
+                        },
+                        "images": {
+                          "description": "Images is a list of Kustomize image override specifications",
+                          "items": {
+                            "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "namePrefix": {
+                          "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "nameSuffix": {
+                          "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "version": {
+                          "description": "Version controls which version of Kustomize to use for rendering manifests",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                      "type": "string"
+                    },
+                    "plugin": {
+                      "description": "Plugin holds config management plugin specific options",
+                      "properties": {
+                        "env": {
+                          "description": "Env is a list of environment variable entries",
+                          "items": {
+                            "description": "EnvEntry represents an entry in the application's environment",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the variable, usually expressed in uppercase",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of the variable",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "array": {
+                                "description": "Array is the value of an array type parameter.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "map": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Map is the value of a map type parameter.",
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the name identifying a parameter.",
+                                "type": "string"
+                              },
+                              "string": {
+                                "description": "String_ is the value of a string type parameter.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ref": {
+                      "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                      "type": "string"
+                    },
+                    "repoURL": {
+                      "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                      "type": "string"
+                    },
+                    "targetRevision": {
+                      "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "repoURL"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sources": {
+                  "description": "Sources is a reference to the application's multiple sources used for comparison",
+                  "items": {
+                    "description": "ApplicationSource contains all required information about the source of an application",
+                    "properties": {
+                      "chart": {
+                        "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+                        "type": "string"
+                      },
+                      "directory": {
+                        "description": "Directory holds path/directory specific options",
+                        "properties": {
+                          "exclude": {
+                            "description": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+                            "type": "string"
+                          },
+                          "include": {
+                            "description": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+                            "type": "string"
+                          },
+                          "jsonnet": {
+                            "description": "Jsonnet holds options specific to Jsonnet",
+                            "properties": {
+                              "extVars": {
+                                "description": "ExtVars is a list of Jsonnet External Variables",
+                                "items": {
+                                  "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "libs": {
+                                "description": "Additional library search dirs",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tlas": {
+                                "description": "TLAS is a list of Jsonnet Top-level Arguments",
+                                "items": {
+                                  "description": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurse": {
+                            "description": "Recurse specifies whether to scan a directory recursively for manifests",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "helm": {
+                        "description": "Helm holds helm specific options",
+                        "properties": {
+                          "fileParameters": {
+                            "description": "FileParameters are file parameters to the helm template",
+                            "items": {
+                              "description": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of the Helm parameter",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "Path is the path to the file containing the values for the Helm parameter",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "ignoreMissingValueFiles": {
+                            "description": "IgnoreMissingValueFiles prevents helm template from failing when valueFiles do not exist locally by not appending them to helm template --values",
+                            "type": "boolean"
+                          },
+                          "parameters": {
+                            "description": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
+                            "items": {
+                              "description": "HelmParameter is a parameter that's passed to helm template during manifest generation",
+                              "properties": {
+                                "forceString": {
+                                  "description": "ForceString determines whether to tell Helm to interpret booleans and numbers as strings",
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the Helm parameter",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value is the value for the Helm parameter",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "passCredentials": {
+                            "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",
+                            "type": "boolean"
+                          },
+                          "releaseName": {
+                            "description": "ReleaseName is the Helm release name to use. If omitted it will use the application name",
+                            "type": "string"
+                          },
+                          "skipCrds": {
+                            "description": "SkipCrds skips custom resource definition installation step (Helm's --skip-crds)",
+                            "type": "boolean"
+                          },
+                          "valueFiles": {
+                            "description": "ValuesFiles is a list of Helm value files to use when generating a template",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "values": {
+                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version is the Helm version to use for templating (\"3\")",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "kustomize": {
+                        "description": "Kustomize holds kustomize specific options",
+                        "properties": {
+                          "commonAnnotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
+                            "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                            "type": "boolean"
+                          },
+                          "commonLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "CommonLabels is a list of additional labels to add to rendered manifests",
+                            "type": "object"
+                          },
+                          "forceCommonAnnotations": {
+                            "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
+                            "type": "boolean"
+                          },
+                          "forceCommonLabels": {
+                            "description": "ForceCommonLabels specifies whether to force applying common labels to resources for Kustomize apps",
+                            "type": "boolean"
+                          },
+                          "images": {
+                            "description": "Images is a list of Kustomize image override specifications",
+                            "items": {
+                              "description": "KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namePrefix": {
+                            "description": "NamePrefix is a prefix appended to resources for Kustomize apps",
+                            "type": "string"
+                          },
+                          "nameSuffix": {
+                            "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "description": "Replicas is a list of Kustomize Replicas override specifications",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number of replicas",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "description": "Name of Deployment or StatefulSet",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "version": {
+                            "description": "Version controls which version of Kustomize to use for rendering manifests",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "path": {
+                        "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+                        "type": "string"
+                      },
+                      "plugin": {
+                        "description": "Plugin holds config management plugin specific options",
+                        "properties": {
+                          "env": {
+                            "description": "Env is a list of environment variable entries",
+                            "items": {
+                              "description": "EnvEntry represents an entry in the application's environment",
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of the variable, usually expressed in uppercase",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value is the value of the variable",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "array": {
+                                  "description": "Array is the value of an array type parameter.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "map": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Map is the value of a map type parameter.",
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "description": "Name is the name identifying a parameter.",
+                                  "type": "string"
+                                },
+                                "string": {
+                                  "description": "String_ is the value of a string type parameter.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ref": {
+                        "description": "Ref is reference to another source within sources field. This field will not be used if used with a `source` tag.",
+                        "type": "string"
+                      },
+                      "repoURL": {
+                        "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                        "type": "string"
+                      },
+                      "targetRevision": {
+                        "description": "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repoURL"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "destination"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "revision": {
+              "description": "Revision contains information about the revision the comparison has been performed to",
+              "type": "string"
+            },
+            "revisions": {
+              "description": "Revisions contains information about the revisions of multiple sources the comparison has been performed to",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "description": "Status is the sync state of the comparison",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/applicationset-argoproj-v1alpha1.json
+++ b/.schemas/applicationset-argoproj-v1alpha1.json
@@ -1,0 +1,18640 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "generators": {
+          "items": {
+            "properties": {
+              "clusterDecisionResource": {
+                "properties": {
+                  "configMapRef": {
+                    "type": "string"
+                  },
+                  "labelSelector": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "requeueAfterSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "values": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "configMapRef"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "clusters": {
+                "properties": {
+                  "selector": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "values": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "git": {
+                "properties": {
+                  "directories": {
+                    "items": {
+                      "properties": {
+                        "exclude": {
+                          "type": "boolean"
+                        },
+                        "path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "files": {
+                    "items": {
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "pathParamPrefix": {
+                    "type": "string"
+                  },
+                  "repoURL": {
+                    "type": "string"
+                  },
+                  "requeueAfterSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "revision": {
+                    "type": "string"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "repoURL",
+                  "revision"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "list": {
+                "properties": {
+                  "elements": {
+                    "items": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "type": "array"
+                  },
+                  "elementsYaml": {
+                    "type": "string"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "elements"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "matrix": {
+                "properties": {
+                  "generators": {
+                    "items": {
+                      "properties": {
+                        "clusterDecisionResource": {
+                          "properties": {
+                            "configMapRef": {
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "properties": {
+                                "matchExpressions": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "configMapRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clusters": {
+                          "properties": {
+                            "selector": {
+                              "properties": {
+                                "matchExpressions": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "directories": {
+                              "items": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "boolean"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "files": {
+                              "items": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "pathParamPrefix": {
+                              "type": "string"
+                            },
+                            "repoURL": {
+                              "type": "string"
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repoURL",
+                            "revision"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "list": {
+                          "properties": {
+                            "elements": {
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "type": "array"
+                            },
+                            "elementsYaml": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "elements"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "matrix": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "merge": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "pullRequest": {
+                          "properties": {
+                            "bitbucketServer": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "project",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "filters": {
+                              "items": {
+                                "properties": {
+                                  "branchMatch": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "gitea": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "github": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "pullRequestState": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "project"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "scmProvider": {
+                          "properties": {
+                            "azureDevOps": {
+                              "properties": {
+                                "accessTokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "teamProject": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "accessTokenRef",
+                                "organization",
+                                "teamProject"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucket": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "appPasswordRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appPasswordRef",
+                                "owner",
+                                "user"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucketServer": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "project": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "project"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneProtocol": {
+                              "type": "string"
+                            },
+                            "filters": {
+                              "items": {
+                                "properties": {
+                                  "branchMatch": {
+                                    "type": "string"
+                                  },
+                                  "labelMatch": {
+                                    "type": "string"
+                                  },
+                                  "pathsDoNotExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pathsExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "repositoryMatch": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "gitea": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "owner"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "github": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "organization"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "includeSubgroups": {
+                                  "type": "boolean"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "group"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "properties": {
+                            "matchExpressions": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "generators"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "merge": {
+                "properties": {
+                  "generators": {
+                    "items": {
+                      "properties": {
+                        "clusterDecisionResource": {
+                          "properties": {
+                            "configMapRef": {
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "properties": {
+                                "matchExpressions": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "configMapRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clusters": {
+                          "properties": {
+                            "selector": {
+                              "properties": {
+                                "matchExpressions": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "directories": {
+                              "items": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "boolean"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "files": {
+                              "items": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "pathParamPrefix": {
+                              "type": "string"
+                            },
+                            "repoURL": {
+                              "type": "string"
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repoURL",
+                            "revision"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "list": {
+                          "properties": {
+                            "elements": {
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "type": "array"
+                            },
+                            "elementsYaml": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "elements"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "matrix": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "merge": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "pullRequest": {
+                          "properties": {
+                            "bitbucketServer": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "project",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "filters": {
+                              "items": {
+                                "properties": {
+                                  "branchMatch": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "gitea": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "github": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "pullRequestState": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "project"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "scmProvider": {
+                          "properties": {
+                            "azureDevOps": {
+                              "properties": {
+                                "accessTokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "teamProject": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "accessTokenRef",
+                                "organization",
+                                "teamProject"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucket": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "appPasswordRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appPasswordRef",
+                                "owner",
+                                "user"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucketServer": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "project": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "project"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneProtocol": {
+                              "type": "string"
+                            },
+                            "filters": {
+                              "items": {
+                                "properties": {
+                                  "branchMatch": {
+                                    "type": "string"
+                                  },
+                                  "labelMatch": {
+                                    "type": "string"
+                                  },
+                                  "pathsDoNotExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pathsExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "repositoryMatch": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "gitea": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "api",
+                                "owner"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "github": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "organization"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "includeSubgroups": {
+                                  "type": "boolean"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "group"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "properties": {
+                            "matchExpressions": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "mergeKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "generators",
+                  "mergeKeys"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "pullRequest": {
+                "properties": {
+                  "bitbucketServer": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "basicAuth": {
+                        "properties": {
+                          "passwordRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "secretName"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "passwordRef",
+                          "username"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "project": {
+                        "type": "string"
+                      },
+                      "repo": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "api",
+                      "project",
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "filters": {
+                    "items": {
+                      "properties": {
+                        "branchMatch": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "gitea": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "repo": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "api",
+                      "owner",
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "github": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "appSecretName": {
+                        "type": "string"
+                      },
+                      "labels": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "repo": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "owner",
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitlab": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "labels": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "project": {
+                        "type": "string"
+                      },
+                      "pullRequestState": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "project"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "requeueAfterSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scmProvider": {
+                "properties": {
+                  "azureDevOps": {
+                    "properties": {
+                      "accessTokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "organization": {
+                        "type": "string"
+                      },
+                      "teamProject": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "accessTokenRef",
+                      "organization",
+                      "teamProject"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "bitbucket": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "appPasswordRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "appPasswordRef",
+                      "owner",
+                      "user"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "bitbucketServer": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "basicAuth": {
+                        "properties": {
+                          "passwordRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "secretName"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "passwordRef",
+                          "username"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "project": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "api",
+                      "project"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloneProtocol": {
+                    "type": "string"
+                  },
+                  "filters": {
+                    "items": {
+                      "properties": {
+                        "branchMatch": {
+                          "type": "string"
+                        },
+                        "labelMatch": {
+                          "type": "string"
+                        },
+                        "pathsDoNotExist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "pathsExist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "repositoryMatch": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "gitea": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "api",
+                      "owner"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "github": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "appSecretName": {
+                        "type": "string"
+                      },
+                      "organization": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "organization"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitlab": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "includeSubgroups": {
+                        "type": "boolean"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "group"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "requeueAfterSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "selector": {
+                "properties": {
+                  "matchExpressions": {
+                    "items": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string"
+                        },
+                        "values": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "goTemplate": {
+          "type": "boolean"
+        },
+        "preservedFields": {
+          "properties": {
+            "annotations": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "strategy": {
+          "properties": {
+            "rollingSync": {
+              "properties": {
+                "steps": {
+                  "items": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "maxUpdate": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syncPolicy": {
+          "properties": {
+            "preserveResourcesOnDeletion": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "destination": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "server": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ignoreDifferences": {
+                  "items": {
+                    "properties": {
+                      "group": {
+                        "type": "string"
+                      },
+                      "jqPathExpressions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "jsonPointers": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "managedFieldsManagers": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "info": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "project": {
+                  "type": "string"
+                },
+                "revisionHistoryLimit": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "source": {
+                  "properties": {
+                    "chart": {
+                      "type": "string"
+                    },
+                    "directory": {
+                      "properties": {
+                        "exclude": {
+                          "type": "string"
+                        },
+                        "include": {
+                          "type": "string"
+                        },
+                        "jsonnet": {
+                          "properties": {
+                            "extVars": {
+                              "items": {
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "libs": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tlas": {
+                              "items": {
+                                "properties": {
+                                  "code": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurse": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "helm": {
+                      "properties": {
+                        "fileParameters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ignoreMissingValueFiles": {
+                          "type": "boolean"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "forceString": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "passCredentials": {
+                          "type": "boolean"
+                        },
+                        "releaseName": {
+                          "type": "string"
+                        },
+                        "skipCrds": {
+                          "type": "boolean"
+                        },
+                        "valueFiles": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "values": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kustomize": {
+                      "properties": {
+                        "commonAnnotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "type": "boolean"
+                        },
+                        "commonLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "forceCommonAnnotations": {
+                          "type": "boolean"
+                        },
+                        "forceCommonLabels": {
+                          "type": "boolean"
+                        },
+                        "images": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "namePrefix": {
+                          "type": "string"
+                        },
+                        "nameSuffix": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "plugin": {
+                      "properties": {
+                        "env": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "array": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "map": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "string": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ref": {
+                      "type": "string"
+                    },
+                    "repoURL": {
+                      "type": "string"
+                    },
+                    "targetRevision": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "repoURL"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sources": {
+                  "items": {
+                    "properties": {
+                      "chart": {
+                        "type": "string"
+                      },
+                      "directory": {
+                        "properties": {
+                          "exclude": {
+                            "type": "string"
+                          },
+                          "include": {
+                            "type": "string"
+                          },
+                          "jsonnet": {
+                            "properties": {
+                              "extVars": {
+                                "items": {
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "libs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tlas": {
+                                "items": {
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurse": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "helm": {
+                        "properties": {
+                          "fileParameters": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "ignoreMissingValueFiles": {
+                            "type": "boolean"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "forceString": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "passCredentials": {
+                            "type": "boolean"
+                          },
+                          "releaseName": {
+                            "type": "string"
+                          },
+                          "skipCrds": {
+                            "type": "boolean"
+                          },
+                          "valueFiles": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "values": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "kustomize": {
+                        "properties": {
+                          "commonAnnotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "type": "boolean"
+                          },
+                          "commonLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "forceCommonAnnotations": {
+                            "type": "boolean"
+                          },
+                          "forceCommonLabels": {
+                            "type": "boolean"
+                          },
+                          "images": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namePrefix": {
+                            "type": "string"
+                          },
+                          "nameSuffix": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "plugin": {
+                        "properties": {
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "array": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "map": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "string": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ref": {
+                        "type": "string"
+                      },
+                      "repoURL": {
+                        "type": "string"
+                      },
+                      "targetRevision": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repoURL"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "syncPolicy": {
+                  "properties": {
+                    "automated": {
+                      "properties": {
+                        "allowEmpty": {
+                          "type": "boolean"
+                        },
+                        "prune": {
+                          "type": "boolean"
+                        },
+                        "selfHeal": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "managedNamespaceMetadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "retry": {
+                      "properties": {
+                        "backoff": {
+                          "properties": {
+                            "duration": {
+                              "type": "string"
+                            },
+                            "factor": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "maxDuration": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "limit": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "syncOptions": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "destination",
+                "project"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "metadata",
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "generators",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "applicationStatus": {
+          "items": {
+            "properties": {
+              "application": {
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "step": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "application",
+              "message",
+              "status",
+              "step"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/appproject-argoproj-v1alpha1.json
+++ b/.schemas/appproject-argoproj-v1alpha1.json
@@ -1,0 +1,362 @@
+{
+  "description": "AppProject provides a logical grouping of applications, providing controls for: * where the apps may deploy to (cluster whitelist) * what may be deployed (repository whitelist, resource whitelist/blacklist) * who can access these applications (roles, OIDC group claims bindings) * and what they can do (RBAC policies) * automation access to these roles (JWT tokens)",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AppProjectSpec is the specification of an AppProject",
+      "properties": {
+        "clusterResourceBlacklist": {
+          "description": "ClusterResourceBlacklist contains list of blacklisted cluster level resources",
+          "items": {
+            "description": "GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "clusterResourceWhitelist": {
+          "description": "ClusterResourceWhitelist contains list of whitelisted cluster level resources",
+          "items": {
+            "description": "GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Description contains optional project description",
+          "type": "string"
+        },
+        "destinations": {
+          "description": "Destinations contains list of destinations available for deployment",
+          "items": {
+            "description": "ApplicationDestination holds information about the application's destination",
+            "properties": {
+              "name": {
+                "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace",
+                "type": "string"
+              },
+              "server": {
+                "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "namespaceResourceBlacklist": {
+          "description": "NamespaceResourceBlacklist contains list of blacklisted namespace level resources",
+          "items": {
+            "description": "GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "namespaceResourceWhitelist": {
+          "description": "NamespaceResourceWhitelist contains list of whitelisted namespace level resources",
+          "items": {
+            "description": "GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "orphanedResources": {
+          "description": "OrphanedResources specifies if controller should monitor orphaned resources of apps in this project",
+          "properties": {
+            "ignore": {
+              "description": "Ignore contains a list of resources that are to be excluded from orphaned resources monitoring",
+              "items": {
+                "description": "OrphanedResourceKey is a reference to a resource to be ignored from",
+                "properties": {
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "warn": {
+              "description": "Warn indicates if warning condition should be created for apps which have orphaned resources",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "permitOnlyProjectScopedClusters": {
+          "description": "PermitOnlyProjectScopedClusters determines whether destinations can only reference clusters which are project-scoped",
+          "type": "boolean"
+        },
+        "roles": {
+          "description": "Roles are user defined RBAC roles associated with this project",
+          "items": {
+            "description": "ProjectRole represents a role that has access to a project",
+            "properties": {
+              "description": {
+                "description": "Description is a description of the role",
+                "type": "string"
+              },
+              "groups": {
+                "description": "Groups are a list of OIDC group claims bound to this role",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "jwtTokens": {
+                "description": "JWTTokens are a list of generated JWT tokens bound to this role",
+                "items": {
+                  "description": "JWTToken holds the issuedAt and expiresAt values of a token",
+                  "properties": {
+                    "exp": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "iat": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "iat"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name is a name for this role",
+                "type": "string"
+              },
+              "policies": {
+                "description": "Policies Stores a list of casbin formatted strings that define access policies for the role in the project",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "signatureKeys": {
+          "description": "SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync",
+          "items": {
+            "description": "SignatureKey is the specification of a key required to verify commit signatures with",
+            "properties": {
+              "keyID": {
+                "description": "The ID of the key in hexadecimal notation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "keyID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "sourceNamespaces": {
+          "description": "SourceNamespaces defines the namespaces application resources are allowed to be created in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sourceRepos": {
+          "description": "SourceRepos contains list of repository URLs which can be used for deployment",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "syncWindows": {
+          "description": "SyncWindows controls when syncs can be run for apps in this project",
+          "items": {
+            "description": "SyncWindow contains the kind, time, duration and attributes that are used to assign the syncWindows to apps",
+            "properties": {
+              "applications": {
+                "description": "Applications contains a list of applications that the window will apply to",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "clusters": {
+                "description": "Clusters contains a list of clusters that the window will apply to",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "duration": {
+                "description": "Duration is the amount of time the sync window will be open",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind defines if the window allows or blocks syncs",
+                "type": "string"
+              },
+              "manualSync": {
+                "description": "ManualSync enables manual syncs when they would otherwise be blocked",
+                "type": "boolean"
+              },
+              "namespaces": {
+                "description": "Namespaces contains a list of namespaces that the window will apply to",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "schedule": {
+                "description": "Schedule is the time the window will begin, specified in cron format",
+                "type": "string"
+              },
+              "timeZone": {
+                "description": "TimeZone of the sync that will be applied to the schedule",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AppProjectStatus contains status information for AppProject CRs",
+      "properties": {
+        "jwtTokensByRole": {
+          "additionalProperties": {
+            "description": "JWTTokens represents a list of JWT tokens",
+            "properties": {
+              "items": {
+                "items": {
+                  "description": "JWTToken holds the issuedAt and expiresAt values of a token",
+                  "properties": {
+                    "exp": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "iat": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "iat"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "JWTTokensByRole contains a list of JWT tokens issued for a given role",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This is our [demo.parca.dev](https://demo.parca.dev) cluster configuration.
 
+* argocd - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-argocd)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-argocd)
+* argocd-applications - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-argocd-applications)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-argocd-applications)
+* cert-manager - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-cert-manager)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-cert-manager)
+* cluster-config - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-cluster-config)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-cluster-config)
+* flux - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-flux)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-flux)
+* grafana - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-grafana)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-grafana)
+* ingress-nginx - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-ingress-nginx)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-ingress-nginx)
+* monitoring - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-monitoring)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-monitoring)
+* parca - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-parca)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-parca)
+
 Ask in one of our channels to be invited to the Scaleway Organization.
 Once you have access you can download the kubeconfig via the UI.
 
@@ -135,4 +145,7 @@ ${COMMAND} | kubeconform \
 
 ## Continuous deployment
 
-Coming Soon.
+* Our [Argo CD](https://argoproj.github.io/cd/) instance is available at: https://demo.parca.dev/argo-cd (see also [argocd/](argocd))
+* Argo CD Applications are configured under [argocd-applications/](argocd-applications)
+* [Flux](https://fluxcd.io/) is used to automate the Parca server and agent image updates (see [flux/](flux))
+* [Renovate](https://docs.renovatebot.com/) is used to update community dependencies (see [GitHub App](https://github.com/apps/renovate) and [renovate.json](renovate.json))

--- a/argocd-applications/README.md
+++ b/argocd-applications/README.md
@@ -1,0 +1,45 @@
+# argocd-applications
+
+See [User Guide - Argo CD](https://argo-cd.readthedocs.io/en/stable/user-guide/).
+
+## Login with the `argocd` CLI
+
+See [argocd/](../argocd#login-with-the-argocd-cli).
+
+## Diff incoming changes
+
+From a branch which has been pushed to the Git repository:
+
+```shell
+argocd app diff "${APPLICATION}" --revision="${BRANCH}"
+```
+
+See also [Argocd app diff | Argo CD](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_diff/)
+
+## Suspend and resume auto-sync
+
+### Suspend
+
+* With `kubectl`:
+
+  ```shell
+  kubectl patch Application \
+    --namespace=argocd "${APPLICATION}" \
+    --type=json --patch='[{ "op": "remove", "path": "/spec/syncPolicy/automated" }]'
+  ```
+
+* With `argocd`:
+
+  ```shell
+  argocd app patch "${APPLICATION}" \
+    --type=json --patch='[{ "op": "remove", "path": "/spec/syncPolicy/automated" }]'
+  ```
+
+### Resume
+
+Re-sync the desired configuration:
+
+```shell
+argocd app sync scaleway-parca-demo-argocd-applications \
+  --resource="argoproj.io:Application:argocd/${APPLICATION}"
+```

--- a/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
+++ b/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
@@ -1,0 +1,67 @@
+local u = import 'utils.libsonnet';
+
+local projects = [
+  u.newProject({
+    name: 'scaleway-parca-demo',
+    description: 'Scaleway Parca Demo cluster',
+  }),
+];
+
+local applications =
+  local common = {
+    project: 'scaleway-parca-demo',
+  };
+
+  [
+    u.newKustomizeApp(common {
+      name: 'argocd',
+      namespace: 'argocd',
+    }),
+    u.newJsonnetApp(common {
+      name: 'argocd-applications',
+      namespace: 'argocd',
+    }) {
+      spec+: {
+        syncPolicy+: {
+          // Disable auto-sync, so apps can be reconfigured ad-hoc
+          automated:: {},
+        },
+      },
+    },
+    u.newKustomizeApp(common {
+      name: 'cluster-config',
+      namespace: 'default',
+    }),
+    u.newHelmApp(common {
+      name: 'cert-manager',
+      namespace: 'cert-manager',
+    }),
+    u.newKustomizeApp(common {
+      name: 'flux',
+      namespace: 'flux-system',
+    }),
+    u.newJsonnetApp(common {
+      name: 'grafana',
+      namespace: 'parca',
+    }),
+    u.newHelmApp(common {
+      name: 'ingress-nginx',
+      namespace: 'ingress-nginx',
+    }),
+    u.newJsonnetApp(common {
+      name: 'monitoring',
+      namespace: 'monitoring',
+    }),
+    u.newJsonnetApp(common {
+      name: 'parca',
+      namespace: 'parca',
+    }),
+  ];
+
+{
+  apiVersion: 'v1',
+  kind: 'List',
+  items:
+    projects +
+    applications,
+}

--- a/argocd-applications/environments/scaleway-parca-demo/spec.json
+++ b/argocd-applications/environments/scaleway-parca-demo/spec.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/scaleway-parca-demo"
+  },
+  "spec": {
+    "apiServer": "https://c2a026b7-5252-4729-b805-aeb910d8d789.api.k8s.nl-ams.scw.cloud:6443",
+    "namespace": "argocd"
+  }
+}

--- a/argocd-applications/lib/utils.libsonnet
+++ b/argocd-applications/lib/utils.libsonnet
@@ -1,0 +1,130 @@
+local clusterName = 'in-cluster';
+local namespace = 'argocd';
+local repoURL = 'https://github.com/parca-dev/demo-deployments.git';
+
+{
+  newProject(params)::
+    local defaults = {
+      name: error 'must provide name',
+      description: error 'must provide description',
+    };
+    local config = defaults + params;
+
+    {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'AppProject',
+      metadata: {
+        name: config.name,
+        namespace: namespace,
+      },
+      spec: {
+        description: config.description,
+        sourceRepos: [repoURL],
+        destinations: [{
+          name: clusterName,
+          namespace: '*',
+        }],
+        clusterResourceWhitelist: [{
+          group: '*',
+          kind: '*',
+        }],
+      },
+    },
+
+  newApp(params)::
+    local defaults = {
+      project: error 'must provide project',
+      name: error 'must provide name',
+      namespace: error 'must provide namespace',
+      path: error 'must provide path',
+      // https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation
+      generatePaths: ['/' + std.split(self.path, '/')[0], '/argocd-applications'],
+    };
+    local config = defaults + params;
+
+    {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: {
+        name: std.join('-', [config.project, config.name]),
+        namespace: namespace,
+        labels: {
+          application: config.name,
+        },
+        annotations: {
+          'argocd.argoproj.io/manifest-generate-paths': std.join(';', std.set(config.generatePaths)),
+        },
+        finalizers: ['resources-finalizer.argocd.argoproj.io/foreground'],
+      },
+      spec: {
+        project: config.project,
+        syncPolicy: {
+          automated: {
+            prune: true,
+          },
+          syncOptions: [
+            'ServerSideApply=true',
+          ],
+        },
+        destination: {
+          name: clusterName,
+          namespace: config.namespace,
+        },
+        source: {
+          repoURL: repoURL,
+          path: config.path,
+          targetRevision: 'HEAD',
+        },
+      },
+    },
+
+  newKustomizeApp(params)::
+    local defaults = {
+      overlay: self.project,
+      path: std.join('/', [self.name, 'overlays', self.overlay]),
+    };
+    local config = defaults + params;
+
+    $.newApp(config),
+
+  newJsonnetApp(params)::
+    local defaults = {
+      environment: self.project,
+      path: std.join('/', [self.name, 'environments', self.environment]),
+    };
+    local config = defaults + params;
+
+    $.newApp(config) {
+      spec+: {
+        source+: {
+          directory+: {
+            jsonnet+: {
+              libs: [
+                std.join('/', [config.name, path])
+                for path in ['vendor', 'lib']
+              ],
+            },
+          },
+        },
+      },
+    },
+
+  newHelmApp(params)::
+    local defaults = {
+      local cfg = self,
+      path: cfg.name,
+      helm: {
+        releaseName: cfg.name,
+        valueFiles: ['values/%s.yaml' % cfg.project],
+      },
+    };
+    local config = defaults + params;
+
+    $.newApp(config) {
+      spec+: {
+        source+: {
+          helm: config.helm,
+        },
+      },
+    },
+}

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -1,0 +1,24 @@
+# argocd
+
+See [Operator Manual - Argo CD](https://argo-cd.readthedocs.io/en/stable/operator-manual/).
+
+## Login with the `argocd` CLI
+
+1. [Install the `argocd` CLI](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
+2. Login with:
+
+   ```shell
+   argocd login demo.parca.dev --grpc-web-root-path /argo-cd --sso
+   ```
+
+3. Optional, validate the authentication was successful with: `argocd account get-user-info`
+
+## Configure GitHub OAuth
+
+1. [Create an OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) under the [`parca-dev` organization](https://github.com/organizations/parca-dev/settings/applications)
+2. Edit the Kubernetes Secret `argocd-secret`: `kubectl edit secret --namespace=argocd argocd-secret`
+3. Add the `dex.github.clientSecret` key using the **base64 encoded** client secret from the first step as value
+
+## Configure Git Webhook
+
+See [Git Webhook Configuration | Argo CD](https://argo-cd.readthedocs.io/en/stable/operator-manual/webhook/).

--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- github.com/argoproj/argo-cd/manifests/cluster-install?ref=5e543518dbdb5384fa61c938ce3e045b4c5be325 # v2.7.1
+
+# Ignoring deprecation for now
+# https://github.com/kubernetes-sigs/kustomize/issues/5049
+patchesStrategicMerge:
+- patches/configure_argocd-cm.yaml
+- patches/set_liveness_and_readiness_probes.yaml
+- patches/set_resource_limits_and_requests.yaml
+
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: argocd-redis
+  patch: |-
+    # set max memory to 65% of requested memory
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --maxmemory 84mb
+
+configMapGenerator:
+- name: argocd-cmd-params-cm
+  behavior: replace
+  literals:
+  - reposerver.parallelism.limit=1
+  - server.insecure=true
+- name: argocd-rbac-cm
+  behavior: replace
+  literals:
+  - policy.default=role:readonly

--- a/argocd/base/patches/configure_argocd-cm.yaml
+++ b/argocd/base/patches/configure_argocd-cm.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: 'false'
+  application.resourceTrackingMethod: annotation
+  resource.exclusions: |
+    - apiGroups:
+      - tanka.dev
+      kinds:
+      - Environment
+      clusters:
+      - '*'
+  users.anonymous.enabled: 'true'
+  statusbadge.enabled: 'true'

--- a/argocd/base/patches/set_liveness_and_readiness_probes.yaml
+++ b/argocd/base/patches/set_liveness_and_readiness_probes.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: dex
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 5558
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 5558

--- a/argocd/base/patches/set_resource_limits_and_requests.yaml
+++ b/argocd/base/patches/set_resource_limits_and_requests.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-application-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-application-controller
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-applicationset-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-applicationset-controller
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: dex
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-notifications-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-notifications-controller
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-repo-server
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-server
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi

--- a/argocd/overlays/scaleway-parca-demo/argocd-server-ingress.yaml
+++ b/argocd/overlays/scaleway-parca-demo/argocd-server-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  labels:
+    app.kubernetes.io/part-of: argocd
+spec:
+  rules:
+  - host: demo.parca.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: argocd-server
+            port:
+              name: http
+        path: /argo-cd
+        pathType: Prefix

--- a/argocd/overlays/scaleway-parca-demo/files/dex.config.yaml
+++ b/argocd/overlays/scaleway-parca-demo/files/dex.config.yaml
@@ -1,0 +1,12 @@
+connectors:
+- type: github
+  id: github
+  name: GitHub
+  config:
+    # https://github.com/organizations/parca-dev/settings/applications/2195045
+    clientID: 63159a3470ccee265b50
+    clientSecret: $dex.github.clientSecret
+    orgs:
+    - name: parca-dev
+      teams:
+      - maintainers

--- a/argocd/overlays/scaleway-parca-demo/files/policy.csv
+++ b/argocd/overlays/scaleway-parca-demo/files/policy.csv
@@ -1,0 +1,1 @@
+g, parca-dev:maintainers, role:admin

--- a/argocd/overlays/scaleway-parca-demo/kustomization.yaml
+++ b/argocd/overlays/scaleway-parca-demo/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- ../../base
+- argocd-server-ingress.yaml
+
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: argocd-server
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --rootpath=/argo-cd
+
+
+configMapGenerator:
+- name: argocd-cm
+  namespace: argocd
+  behavior: merge
+  literals:
+  - url=https://demo.parca.dev/argo-cd
+  files:
+  - dex.config=files/dex.config.yaml
+- name: argocd-rbac-cm
+  namespace: argocd
+  behavior: merge
+  files:
+  - files/policy.csv

--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -2,6 +2,16 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: argocd
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: cert-manager
 ---
 apiVersion: v1


### PR DESCRIPTION
This configures Argo CD to deploy manifest updates to the demo environment automatically.

The UI is available at: https://demo.parca.dev/argo-cd
It is readable to the public, and admin access is provided to the GitHub team `parca-dev/maintainers`