### PR TITLE
fix(monitoring): disable prometheus alerting

### DIFF
--- a/monitoring/lib/prometheus.libsonnet
+++ b/monitoring/lib/prometheus.libsonnet
@@ -13,7 +13,9 @@ local defaults = {
     commonLabels+: {
       'app.kubernetes.io/instance': $.prometheus.name,
     },
-    alerting: {},
+    alerting: {
+      alertmanagers: [],
+    },
     enableFeatures: ['native-histograms'],
     resources+: {
       limits+: {


### PR DESCRIPTION
We do not have `alertmanager` deployed and RBAC is not there either, it should fix some spamming in the logs:

```
ts=2023-05-12T17:45:35.159Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:169: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:monitoring:prometheus-parca\" cannot list resource \"pods\" in API group \"\" in the namespace \"monitoring\""
```

```diff
$ argocd app diff scaleway-parca-demo-monitoring --revision=fix/monitoring/disable-alerting
===== monitoring.coreos.com/Prometheus monitoring/parca ======
diff --git a/tmp/argocd-diff2890939402/parca-live.yaml b/tmp/argocd-diff2890939402/parca
index 643590d..167b38d 100644
--- a/tmp/argocd-diff2890939402/parca-live.yaml
+++ b/tmp/argocd-diff2890939402/parca
@@ -170,11 +170,7 @@ metadata:
   uid: 1b11e88b-4254-43bf-8738-f5a84335dbda
 spec:
   alerting:
-    alertmanagers:
-    - apiVersion: v2
-      name: alertmanager-
-      namespace: monitoring
-      port: web
+    alertmanagers: []
   enableFeatures:
   - native-histograms
   evaluationInterval: 30s
```