### PR TITLE
fix(parca): fix agent networkpolicy for monitoring

### DIFF
--- a/cert-manager/templates/networkpolicy.yaml
+++ b/cert-manager/templates/networkpolicy.yaml
@@ -9,19 +9,6 @@ metadata:
 spec:
   egress:
   - {}
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: monitoring
-      podSelector:
-        matchExpressions:
-        - key: app.kubernetes.io/name
-          operator: In
-          values:
-          - prometheus
-    ports:
-    - port: 9402
   podSelector:
     matchLabels:
       app.kubernetes.io/name: cert-manager
@@ -29,4 +16,3 @@ spec:
       app.kubernetes.io/component: controller
   policyTypes:
   - Egress
-  - Ingress

--- a/parca/lib/parca-agent.libsonnet
+++ b/parca/lib/parca-agent.libsonnet
@@ -60,7 +60,7 @@ function(params={})
             {
               namespaceSelector: {
                 matchLabels: {
-                  name: 'monitoring',
+                  'kubernetes.io/metadata.name': 'monitoring',
                 },
               },
               podSelector: {


### PR DESCRIPTION
```diff
$ argocd app diff scaleway-parca-demo-parca --revision=fix/parca/agent-netpol
===== networking.k8s.io/NetworkPolicy parca/parca-agent ======
diff --git a/tmp/argocd-diff3468075764/parca-agent-live.yaml b/tmp/argocd-diff3468075764/parca-agent
index 47d6c69..adcaea0 100644
--- a/tmp/argocd-diff3468075764/parca-agent-live.yaml
+++ b/tmp/argocd-diff3468075764/parca-agent
@@ -55,7 +55,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: monitoring
+          kubernetes.io/metadata.name: monitoring
       podSelector:
         matchLabels:
           app.kubernetes.io/name: prometheus
```