### PR TITLE
fix(flux): bump image-reflector-controller memory again

### DIFF
--- a/flux/base/image-reflector-controller/patches/set_resources_limits_requests.yaml
+++ b/flux/base/image-reflector-controller/patches/set_resources_limits_requests.yaml
@@ -10,7 +10,7 @@ spec:
         resources:
           limits:
             cpu: null
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi


### PR DESCRIPTION
It keeps OOM'ing, something seems wrong with this component, need to look into allocation profiles