### PR TITLE
feat: pull parca/parca-agent/flux profiles

### DIFF
--- a/flux/base/image-automation-controller/networkpolicy.yaml
+++ b/flux/base/image-automation-controller/networkpolicy.yaml
@@ -5,8 +5,23 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - protocol: TCP
+      port: http-prom
   podSelector:
     matchLabels:
       app.kubernetes.io/component: image-automation-controller
   policyTypes:
   - Egress
+  - Ingress

--- a/flux/base/image-reflector-controller/networkpolicy.yaml
+++ b/flux/base/image-reflector-controller/networkpolicy.yaml
@@ -5,8 +5,23 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - protocol: TCP
+      port: http-prom
   podSelector:
     matchLabels:
       app.kubernetes.io/component: image-reflector-controller
   policyTypes:
   - Egress
+  - Ingress

--- a/flux/base/source-controller/networkpolicy.yaml
+++ b/flux/base/source-controller/networkpolicy.yaml
@@ -5,8 +5,23 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - protocol: TCP
+      port: http-prom
   podSelector:
     matchLabels:
       app.kubernetes.io/component: source-controller
   policyTypes:
   - Egress
+  - Ingress

--- a/parca-devel/jsonnetfile.json
+++ b/parca-devel/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/parca-dev/jsonnet-libs.git",
+          "subdir": "scrape-configs"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/parca-dev/parca-agent.git",
           "subdir": "deploy/lib/parca-agent"
         }

--- a/parca-devel/jsonnetfile.lock.json
+++ b/parca-devel/jsonnetfile.lock.json
@@ -4,6 +4,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/parca-dev/jsonnet-libs.git",
+          "subdir": "scrape-configs"
+        }
+      },
+      "version": "84af9d41972b247ed36e0bb3e80ab40e0de87dc2",
+      "sum": "9Sl1vzn4bXH/NvdjSXEVtuq9joATwmh3S+8N5WmOO2U="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/parca-dev/parca-agent.git",
           "subdir": "deploy/lib/parca-agent"
         }

--- a/parca-devel/lib/parca-agent.libsonnet
+++ b/parca-devel/lib/parca-agent.libsonnet
@@ -70,6 +70,18 @@ function(params={})
                 },
               },
             },
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'parca',
+                },
+              },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'parca',
+                },
+              },
+            },
           ],
           ports: [{
             port: 'http',

--- a/parca-devel/lib/parca.libsonnet
+++ b/parca-devel/lib/parca.libsonnet
@@ -1,3 +1,4 @@
+local scrapeConfigs = import 'github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet';
 local p = import 'github.com/parca-dev/parca/deploy/lib/parca/parca.libsonnet';
 local versions = std.parseYaml(importstr './versions.yaml');
 
@@ -24,12 +25,114 @@ local defaults = {
     },
   },
   corsAllowedOrigins: '*',
+  podProfilers: [
+    {
+      name: 'parca-agent-devel',
+      namespace: $.namespace,
+      podProfileEndpoints: [{
+        port: 'http',
+        relabelings: [
+          {
+            source_labels: ['__meta_kubernetes_pod_node_name'],
+            target_label: 'instance',
+          },
+          {
+            source_labels: ['__meta_kubernetes_service_label_app_kubernetes_io_version'],
+            target_label: 'version',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'parca-agent',
+          'app.kubernetes.io/instance': 'parca-agent-devel',
+          'app.kubernetes.io/component': 'observability',
+        },
+      },
+    },
+  ],
+  serviceProfilers: [
+    {
+      name: $.name,
+      namespace: $.namespace,
+      endpoints: [{
+        port: 'http',
+        profilingConfig: {
+          pprof_config: {
+            fgprof: {
+              enabled: true,
+              path: '/debug/pprof/fgprof',
+            },
+          },
+        },
+        relabelings: [
+          {
+            source_labels: ['namespace', 'pod'],
+            separator: '/',
+            target_label: 'instance',
+          },
+          {
+            source_labels: ['__meta_kubernetes_pod_label_app_kubernetes_io_version'],
+            target_label: 'version',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: $.podLabelSelector,
+      },
+    },
+  ],
+  config+:
+    scrapeConfigs.generatePodProfilersConfig($.podProfilers) +
+    scrapeConfigs.generateServiceProfilersConfig($.serviceProfilers),
 };
 
 function(params)
   local config = defaults + params;
 
   p(config) {
+    clusterRole: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: $.config.name,
+        namespace: $.config.namespace,
+        labels: $.config.commonLabels,
+      },
+      rules: [
+        {
+          apiGroups: [''],
+          resources: ['services', 'endpoints', 'pods'],
+          verbs: ['get', 'list', 'watch'],
+        },
+        {
+          apiGroups: ['networking.k8s.io'],
+          resources: ['ingresses'],
+          verbs: ['get', 'list', 'watch'],
+        },
+      ],
+    },
+
+    clusterRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: $.config.name,
+        namespace: $.config.namespace,
+        labels: $.config.commonLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: $.config.name,
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: $.config.name,
+        namespace: $.config.namespace,
+      }],
+    },
+
     deployment+: {
       spec+: {
         strategy: {

--- a/parca-devel/lib/versions.yaml
+++ b/parca-devel/lib/versions.yaml
@@ -1,4 +1,4 @@
 # Maintained by Flux
-# See flux-image-update/overlays/scaleway-parca-demo/ for the configuration
+# See flux/overlays/scaleway-parca-demo/ for the configuration
 parca: main-1685386783-1b1a3d6d # {"$imagepolicy": "flux-system:parca:tag"}
 parcaAgent: main-1685369201-1d11e821 # {"$imagepolicy": "flux-system:parca-agent:tag"}

--- a/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/common.libsonnet
+++ b/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/common.libsonnet
@@ -1,0 +1,16 @@
+{
+  // sanitizeLabelName sanitizes a given string to be used as a Parca label name.
+  // Jsonnet equivalent of: regexp.MustCompile(`[^a-zA-Z0-9_]`).ReplaceAllString(name, "_")
+  sanitizeLabelName(name):
+    std.join('', [
+      if c >= 'a' && c <= 'z' ||
+         c >= 'A' && c <= 'Z' ||
+         c >= '0' && c <= '9' ||
+         c == '_'
+      then
+        c
+      else
+        '_'
+      for c in std.stringChars(name)
+    ]),
+}

--- a/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/podprofilers.libsonnet
+++ b/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/podprofilers.libsonnet
@@ -1,0 +1,205 @@
+local common = import './common.libsonnet';
+
+local defaults = {
+  name: 'must provide name',
+  namespace: 'must provide namespace',
+  jobLabel: '',
+  podTargetLabels: [],
+  podProfileEndpoints: 'must provide endpoints',
+  selector: 'must provide selector',
+  namespaceSelector: {
+    any: false,
+    matchNames: [],
+  },
+};
+
+local podProfileEndpointDefaults = {
+  port: error 'must provide port',
+  profilingConfig: {},
+  scheme: 'http',
+  interval: '10s',
+  scrapeTimeout: '0s',
+  relabelings: [],
+  followRedirects: true,
+};
+
+local selectorDefaults = {
+  matchLabels: {},
+  matchExpressions: [],
+};
+
+{
+  // generatePodProfilersConfig generates scrape configs for a list of podProfiler objects.
+  generatePodProfilersConfig(podProfilers): {
+    scrape_configs+: [
+      {
+        local pod = defaults + p,
+        local ep = podProfileEndpointDefaults + pod.podProfileEndpoints[i],
+        local selector = selectorDefaults + pod.selector,
+
+        assert std.isObject(selector),
+        assert std.isObject(selector.matchLabels) && std.length(selector.matchLabels) > 0 ||
+               std.isArray(selector.matchExpressions) && std.length(selector.matchExpressions) > 0,
+
+        job_name: 'PodProfiler/%s/%s/%d' % [pod.namespace, pod.name, i],
+        scrape_interval: ep.interval,
+        scrape_timeout: ep.scrapeTimeout,
+        profiling_config: ep.profilingConfig,
+        scheme: ep.scheme,
+        relabel_configs:
+          // Relabel prometheus job name into a meta label
+          [
+            {
+              source_labels: ['job'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: '__tmp_prometheus_job_name',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ] +
+
+          // Exact label matches.
+          [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(labelKey)],
+              separator: ';',
+              regex: selector.matchLabels[labelKey],
+              replacement: '$1',
+              action: 'keep',
+            }
+            for labelKey in std.objectFields(selector.matchLabels)
+
+          ] +
+
+          // Set based label matching. We have to map the valid relations
+          // `In`, `NotIn`, `Exists`, and `DoesNotExist`, into relabeling rules.
+          [
+            if exp.operator == 'In' then {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotIn' then {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'drop',
+            } else if exp.operator == 'Exists' then {
+              source_labels: ['__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotExits' then {
+              source_labels: ['__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'drop',
+            } else error 'unknown expression operator: ' + exp.operator
+            for exp in selector.matchExpressions
+          ] +
+
+          [
+            // Filter targets based on correct port for the endpoint.
+            {
+              source_labels: ['__meta_kubernetes_pod_container_port_name'],
+              separator: ';',
+              regex: ep.port,
+              replacement: '$1',
+              action: 'keep',
+            },
+
+            // Relabel namespace and pod and service labels into proper labels.
+            {
+              source_labels: ['__meta_kubernetes_namespace'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'namespace',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_container_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'container',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+            // Relabel targetLabels from Pod onto target.
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in pod.podTargetLabels
+          ] + [
+
+            // Set job label
+            {
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'job',
+              replacement: '%s/%s' % [pod.namespace, pod.name],
+              action: 'replace',
+            },
+          ] +
+
+          if pod.jobLabel != '' then [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(pod.jobLabel)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ]
+
+          else [] + [
+            {
+              target_label: 'endpoint',
+              separator: ';',
+              regex: '(.*)',
+              replacement: ep.port,
+              action: 'replace',
+            },
+          ] + ep.relabelings,
+
+        kubernetes_sd_configs: [{
+          role: 'pod',
+          kubeconfig_file: '',
+          follow_redirects: ep.followRedirects,
+          namespaces: {
+            own_namespace: false,
+            names:
+              if pod.namespaceSelector.any then
+                []
+              else if std.length(pod.namespaceSelector.matchNames) == 0 then
+                [pod.namespace]
+              else pod.namespaceSelector.matchNames,
+          },
+        }],
+      }
+      for p in podProfilers
+      for i in std.range(0, std.length(p.podProfileEndpoints) - 1)
+    ],
+  },
+}

--- a/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet
+++ b/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet
@@ -1,0 +1,2 @@
+(import 'podprofilers.libsonnet') +
+(import 'serviceprofilers.libsonnet')

--- a/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/serviceprofilers.libsonnet
+++ b/parca-devel/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/serviceprofilers.libsonnet
@@ -1,0 +1,275 @@
+local common = import './common.libsonnet';
+
+local defaults = {
+  name: 'must provide name',
+  namespace: 'must provide namespace',
+  jobLabel: '',
+  targetLabels: [],
+  podTargetLabels: [],
+  endpoints: 'must provide endpoints',
+  selector: 'must provide selector',
+  namespaceSelector: {
+    any: false,
+    matchNames: [],
+  },
+};
+
+local endpointDefaults = {
+  port: '',
+  profilingConfig: {},
+  targetPort: '',
+  scheme: 'http',
+  interval: '10s',
+  scrapeTimeout: '0s',
+  relabelings: [],
+  followRedirects: true,
+};
+
+local selectorDefaults = {
+  matchLabels: {},
+  matchExpressions: [],
+};
+
+{
+  // generateServiceProfilersConfig generates scrape configs for a list of serviceProfiler objects.
+  generateServiceProfilersConfig(serviceProfilers): {
+    scrape_configs+: [
+      {
+        local svc = defaults + s,
+        local ep = endpointDefaults + svc.endpoints[i],
+        local selector = selectorDefaults + svc.selector,
+
+        assert std.isObject(selector),
+        assert ep.port == '' || ep.targetPort == '',
+        assert ep.port != '' || ep.targetPort != '',
+        assert std.isObject(selector.matchLabels) && std.length(selector.matchLabels) > 0 ||
+               std.isArray(selector.matchExpressions) && std.length(selector.matchExpressions) > 0,
+
+        job_name: 'ServiceProfiler/%s/%s/%d' % [svc.namespace, svc.name, i],
+        scrape_interval: ep.interval,
+        scrape_timeout: ep.scrapeTimeout,
+        profiling_config: ep.profilingConfig,
+        scheme: ep.scheme,
+        relabel_configs:
+          // Relabel prometheus job name into a meta label
+          [
+            {
+              source_labels: ['job'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: '__tmp_prometheus_job_name',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ] +
+
+          // Exact label matches.
+          [
+
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(labelKey)],
+              separator: ';',
+              regex: selector.matchLabels[labelKey],
+              replacement: '$1',
+              action: 'keep',
+            }
+            for labelKey in std.objectFields(selector.matchLabels)
+
+          ] +
+
+          // Set based label matching. We have to map the valid relations
+          // `In`, `NotIn`, `Exists`, and `DoesNotExist`, into relabeling rules.
+          [
+            if exp.operator == 'In' then {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotIn' then {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'drop',
+            } else if exp.operator == 'Exists' then {
+              source_labels: ['__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotExits' then {
+              source_labels: ['__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'drop',
+            } else error 'unknown expression operator: ' + exp.operator
+            for exp in selector.matchExpressions
+
+            // Filter targets based on correct port for the endpoint.
+          ] + (
+            if ep.port != '' then [
+              {
+                source_labels: ['__meta_kubernetes_endpoint_port_name'],
+                separator: ';',
+                regex: ep.port,
+                replacement: '$1',
+                action: 'keep',
+              },
+            ] else if ep.targetPort != '' then
+              if std.isString(ep.targetPort) then [
+                {
+                  source_labels: ['__meta_kubernetes_pod_container_port_name'],
+                  separator: ';',
+                  regex: ep.targetPort,
+                  replacement: '$1',
+                  action: 'keep',
+                },
+              ] else if std.isNumber(ep.targetPort) then [
+                {
+                  source_labels: ['__meta_kubernetes_pod_container_port_number'],
+                  separator: ';',
+                  regex: ep.targetPort,
+                  replacement: '$1',
+                  action: 'keep',
+                },
+              ] else error 'targetPort must be a string or integer'
+            else error 'could not set endpoint port selector'
+          ) + [
+
+            {
+              source_labels: ['__meta_kubernetes_endpoint_address_target_kind', '__meta_kubernetes_endpoint_address_target_name'],
+              separator: ';',
+              regex: 'Node;(.*)',
+              target_label: 'node',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_endpoint_address_target_kind', '__meta_kubernetes_endpoint_address_target_name'],
+              separator: ';',
+              regex: 'Pod;(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_namespace'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'namespace',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_service_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'service',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_container_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'container',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+            // Relabel targetLabels from Service onto target.
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in svc.targetLabels
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in svc.podTargetLabels
+          ] + [
+
+            // Set job label
+            {
+              source_labels: ['__meta_kubernetes_service_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+          ] + if svc.jobLabel != '' then [
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(svc.jobLabel)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+          ] else
+            [] + (
+              if ep.port != '' then [
+                {
+                  target_label: 'endpoint',
+                  separator: ';',
+                  regex: '(.*)',
+                  replacement: ep.port,
+                  action: 'replace',
+                },
+              ] else if ep.targetPort != '' then [
+                {
+                  target_label: 'endpoint',
+                  separator: ';',
+                  regex: '(.*)',
+                  replacement: ep.targetPort,
+                  action: 'replace',
+                },
+              ] else error 'could not set endpoint label'
+            ) +
+
+            ep.relabelings,
+
+        kubernetes_sd_configs: [{
+          role: 'endpoints',
+          kubeconfig_file: '',
+          follow_redirects: ep.followRedirects,
+          namespaces: {
+            own_namespace: false,
+            names:
+              if svc.namespaceSelector.any then
+                []
+              else if std.length(svc.namespaceSelector.matchNames) == 0 then
+                [svc.namespace]
+              else svc.namespaceSelector.matchNames,
+          },
+        }],
+      }
+      for s in serviceProfilers
+      for i in std.range(0, std.length(s.endpoints) - 1)
+    ],
+  },
+}

--- a/parca/jsonnetfile.json
+++ b/parca/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/parca-dev/jsonnet-libs.git",
+          "subdir": "scrape-configs"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/parca-dev/parca-agent.git",
           "subdir": "deploy/lib/parca-agent"
         }

--- a/parca/jsonnetfile.lock.json
+++ b/parca/jsonnetfile.lock.json
@@ -4,6 +4,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/parca-dev/jsonnet-libs.git",
+          "subdir": "scrape-configs"
+        }
+      },
+      "version": "84af9d41972b247ed36e0bb3e80ab40e0de87dc2",
+      "sum": "9Sl1vzn4bXH/NvdjSXEVtuq9joATwmh3S+8N5WmOO2U="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/parca-dev/parca-agent.git",
           "subdir": "deploy/lib/parca-agent"
         }

--- a/parca/lib/parca-agent.libsonnet
+++ b/parca/lib/parca-agent.libsonnet
@@ -69,6 +69,18 @@ function(params={})
                 },
               },
             },
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'parca',
+                },
+              },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'parca',
+                },
+              },
+            },
           ],
           ports: [{
             port: 'http',

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -1,3 +1,4 @@
+local scrapeConfigs = import 'github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet';
 local p = import 'github.com/parca-dev/parca/deploy/lib/parca/parca.libsonnet';
 
 local defaults = {
@@ -22,12 +23,174 @@ local defaults = {
     },
   },
   corsAllowedOrigins: '*',
+  podProfilers: [
+    {
+      name: 'parca-agent',
+      namespace: $.namespace,
+      podProfileEndpoints: [{
+        port: 'http',
+        relabelings: [
+          {
+            source_labels: ['__meta_kubernetes_pod_node_name'],
+            target_label: 'instance',
+          },
+          {
+            source_labels: ['__meta_kubernetes_service_label_app_kubernetes_io_version'],
+            target_label: 'version',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'parca-agent',
+          'app.kubernetes.io/instance': 'parca-agent',
+          'app.kubernetes.io/component': 'observability',
+        },
+      },
+    },
+    {
+      name: 'image-automation-controller',
+      namespace: 'flux-system',
+      podProfileEndpoints: [{
+        port: 'http-prom',
+        relabelings: [
+          {
+            source_labels: ['namespace', 'pod'],
+            separator: '/',
+            target_label: 'instance',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'flux',
+          'app.kubernetes.io/component': 'image-automation-controller',
+        },
+      },
+    },
+    {
+      name: 'image-reflector-controller',
+      namespace: 'flux-system',
+      podProfileEndpoints: [{
+        port: 'http-prom',
+        relabelings: [
+          {
+            source_labels: ['namespace', 'pod'],
+            separator: '/',
+            target_label: 'instance',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'flux',
+          'app.kubernetes.io/component': 'image-reflector-controller',
+        },
+      },
+    },
+    {
+      name: 'source-controller',
+      namespace: 'flux-system',
+      podProfileEndpoints: [{
+        port: 'http-prom',
+        relabelings: [
+          {
+            source_labels: ['namespace', 'pod'],
+            separator: '/',
+            target_label: 'instance',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'flux',
+          'app.kubernetes.io/component': 'source-controller',
+        },
+      },
+    },
+  ],
+  serviceProfilers: [
+    {
+      name: $.name,
+      namespace: $.namespace,
+      endpoints: [{
+        port: 'http',
+        profilingConfig: {
+          pprof_config: {
+            fgprof: {
+              enabled: true,
+              path: '/debug/pprof/fgprof',
+            },
+          },
+        },
+        relabelings: [
+          {
+            source_labels: ['namespace', 'pod'],
+            separator: '/',
+            target_label: 'instance',
+          },
+          {
+            source_labels: ['__meta_kubernetes_pod_label_app_kubernetes_io_version'],
+            target_label: 'version',
+          },
+        ],
+      }],
+      selector: {
+        matchLabels: $.podLabelSelector,
+      },
+    },
+  ],
+  config+:
+    scrapeConfigs.generatePodProfilersConfig($.podProfilers) +
+    scrapeConfigs.generateServiceProfilersConfig($.serviceProfilers),
 };
 
 function(params)
   local config = defaults + params;
 
   p(config) {
+    clusterRole: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: $.config.name,
+        namespace: $.config.namespace,
+        labels: $.config.commonLabels,
+      },
+      rules: [
+        {
+          apiGroups: [''],
+          resources: ['services', 'endpoints', 'pods'],
+          verbs: ['get', 'list', 'watch'],
+        },
+        {
+          apiGroups: ['networking.k8s.io'],
+          resources: ['ingresses'],
+          verbs: ['get', 'list', 'watch'],
+        },
+      ],
+    },
+
+    clusterRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: $.config.name,
+        namespace: $.config.namespace,
+        labels: $.config.commonLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: $.config.name,
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: $.config.name,
+        namespace: $.config.namespace,
+      }],
+    },
+
     deployment+: {
       spec+: {
         strategy: {

--- a/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/common.libsonnet
+++ b/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/common.libsonnet
@@ -1,0 +1,16 @@
+{
+  // sanitizeLabelName sanitizes a given string to be used as a Parca label name.
+  // Jsonnet equivalent of: regexp.MustCompile(`[^a-zA-Z0-9_]`).ReplaceAllString(name, "_")
+  sanitizeLabelName(name):
+    std.join('', [
+      if c >= 'a' && c <= 'z' ||
+         c >= 'A' && c <= 'Z' ||
+         c >= '0' && c <= '9' ||
+         c == '_'
+      then
+        c
+      else
+        '_'
+      for c in std.stringChars(name)
+    ]),
+}

--- a/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/podprofilers.libsonnet
+++ b/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/podprofilers.libsonnet
@@ -1,0 +1,205 @@
+local common = import './common.libsonnet';
+
+local defaults = {
+  name: 'must provide name',
+  namespace: 'must provide namespace',
+  jobLabel: '',
+  podTargetLabels: [],
+  podProfileEndpoints: 'must provide endpoints',
+  selector: 'must provide selector',
+  namespaceSelector: {
+    any: false,
+    matchNames: [],
+  },
+};
+
+local podProfileEndpointDefaults = {
+  port: error 'must provide port',
+  profilingConfig: {},
+  scheme: 'http',
+  interval: '10s',
+  scrapeTimeout: '0s',
+  relabelings: [],
+  followRedirects: true,
+};
+
+local selectorDefaults = {
+  matchLabels: {},
+  matchExpressions: [],
+};
+
+{
+  // generatePodProfilersConfig generates scrape configs for a list of podProfiler objects.
+  generatePodProfilersConfig(podProfilers): {
+    scrape_configs+: [
+      {
+        local pod = defaults + p,
+        local ep = podProfileEndpointDefaults + pod.podProfileEndpoints[i],
+        local selector = selectorDefaults + pod.selector,
+
+        assert std.isObject(selector),
+        assert std.isObject(selector.matchLabels) && std.length(selector.matchLabels) > 0 ||
+               std.isArray(selector.matchExpressions) && std.length(selector.matchExpressions) > 0,
+
+        job_name: 'PodProfiler/%s/%s/%d' % [pod.namespace, pod.name, i],
+        scrape_interval: ep.interval,
+        scrape_timeout: ep.scrapeTimeout,
+        profiling_config: ep.profilingConfig,
+        scheme: ep.scheme,
+        relabel_configs:
+          // Relabel prometheus job name into a meta label
+          [
+            {
+              source_labels: ['job'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: '__tmp_prometheus_job_name',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ] +
+
+          // Exact label matches.
+          [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(labelKey)],
+              separator: ';',
+              regex: selector.matchLabels[labelKey],
+              replacement: '$1',
+              action: 'keep',
+            }
+            for labelKey in std.objectFields(selector.matchLabels)
+
+          ] +
+
+          // Set based label matching. We have to map the valid relations
+          // `In`, `NotIn`, `Exists`, and `DoesNotExist`, into relabeling rules.
+          [
+            if exp.operator == 'In' then {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotIn' then {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'drop',
+            } else if exp.operator == 'Exists' then {
+              source_labels: ['__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotExits' then {
+              source_labels: ['__meta_kubernetes_pod_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'drop',
+            } else error 'unknown expression operator: ' + exp.operator
+            for exp in selector.matchExpressions
+          ] +
+
+          [
+            // Filter targets based on correct port for the endpoint.
+            {
+              source_labels: ['__meta_kubernetes_pod_container_port_name'],
+              separator: ';',
+              regex: ep.port,
+              replacement: '$1',
+              action: 'keep',
+            },
+
+            // Relabel namespace and pod and service labels into proper labels.
+            {
+              source_labels: ['__meta_kubernetes_namespace'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'namespace',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_container_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'container',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+            // Relabel targetLabels from Pod onto target.
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in pod.podTargetLabels
+          ] + [
+
+            // Set job label
+            {
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'job',
+              replacement: '%s/%s' % [pod.namespace, pod.name],
+              action: 'replace',
+            },
+          ] +
+
+          if pod.jobLabel != '' then [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(pod.jobLabel)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ]
+
+          else [] + [
+            {
+              target_label: 'endpoint',
+              separator: ';',
+              regex: '(.*)',
+              replacement: ep.port,
+              action: 'replace',
+            },
+          ] + ep.relabelings,
+
+        kubernetes_sd_configs: [{
+          role: 'pod',
+          kubeconfig_file: '',
+          follow_redirects: ep.followRedirects,
+          namespaces: {
+            own_namespace: false,
+            names:
+              if pod.namespaceSelector.any then
+                []
+              else if std.length(pod.namespaceSelector.matchNames) == 0 then
+                [pod.namespace]
+              else pod.namespaceSelector.matchNames,
+          },
+        }],
+      }
+      for p in podProfilers
+      for i in std.range(0, std.length(p.podProfileEndpoints) - 1)
+    ],
+  },
+}

--- a/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet
+++ b/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/scrape-configs.libsonnet
@@ -1,0 +1,2 @@
+(import 'podprofilers.libsonnet') +
+(import 'serviceprofilers.libsonnet')

--- a/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/serviceprofilers.libsonnet
+++ b/parca/vendor/github.com/parca-dev/jsonnet-libs/scrape-configs/serviceprofilers.libsonnet
@@ -1,0 +1,275 @@
+local common = import './common.libsonnet';
+
+local defaults = {
+  name: 'must provide name',
+  namespace: 'must provide namespace',
+  jobLabel: '',
+  targetLabels: [],
+  podTargetLabels: [],
+  endpoints: 'must provide endpoints',
+  selector: 'must provide selector',
+  namespaceSelector: {
+    any: false,
+    matchNames: [],
+  },
+};
+
+local endpointDefaults = {
+  port: '',
+  profilingConfig: {},
+  targetPort: '',
+  scheme: 'http',
+  interval: '10s',
+  scrapeTimeout: '0s',
+  relabelings: [],
+  followRedirects: true,
+};
+
+local selectorDefaults = {
+  matchLabels: {},
+  matchExpressions: [],
+};
+
+{
+  // generateServiceProfilersConfig generates scrape configs for a list of serviceProfiler objects.
+  generateServiceProfilersConfig(serviceProfilers): {
+    scrape_configs+: [
+      {
+        local svc = defaults + s,
+        local ep = endpointDefaults + svc.endpoints[i],
+        local selector = selectorDefaults + svc.selector,
+
+        assert std.isObject(selector),
+        assert ep.port == '' || ep.targetPort == '',
+        assert ep.port != '' || ep.targetPort != '',
+        assert std.isObject(selector.matchLabels) && std.length(selector.matchLabels) > 0 ||
+               std.isArray(selector.matchExpressions) && std.length(selector.matchExpressions) > 0,
+
+        job_name: 'ServiceProfiler/%s/%s/%d' % [svc.namespace, svc.name, i],
+        scrape_interval: ep.interval,
+        scrape_timeout: ep.scrapeTimeout,
+        profiling_config: ep.profilingConfig,
+        scheme: ep.scheme,
+        relabel_configs:
+          // Relabel prometheus job name into a meta label
+          [
+            {
+              source_labels: ['job'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: '__tmp_prometheus_job_name',
+              replacement: '$1',
+              action: 'replace',
+            },
+          ] +
+
+          // Exact label matches.
+          [
+
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(labelKey)],
+              separator: ';',
+              regex: selector.matchLabels[labelKey],
+              replacement: '$1',
+              action: 'keep',
+            }
+            for labelKey in std.objectFields(selector.matchLabels)
+
+          ] +
+
+          // Set based label matching. We have to map the valid relations
+          // `In`, `NotIn`, `Exists`, and `DoesNotExist`, into relabeling rules.
+          [
+            if exp.operator == 'In' then {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotIn' then {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(exp.Key), '__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: '(%s);true' % std.join('|', exp.Values),
+              replacement: '$1',
+              action: 'drop',
+            } else if exp.operator == 'Exists' then {
+              source_labels: ['__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'keep',
+            } else if exp.operator == 'NotExits' then {
+              source_labels: ['__meta_kubernetes_service_labelpresent_' + common.sanitizeLabelName(exp.Key)],
+              separator: ';',
+              regex: 'true',
+              replacement: '$1',
+              action: 'drop',
+            } else error 'unknown expression operator: ' + exp.operator
+            for exp in selector.matchExpressions
+
+            // Filter targets based on correct port for the endpoint.
+          ] + (
+            if ep.port != '' then [
+              {
+                source_labels: ['__meta_kubernetes_endpoint_port_name'],
+                separator: ';',
+                regex: ep.port,
+                replacement: '$1',
+                action: 'keep',
+              },
+            ] else if ep.targetPort != '' then
+              if std.isString(ep.targetPort) then [
+                {
+                  source_labels: ['__meta_kubernetes_pod_container_port_name'],
+                  separator: ';',
+                  regex: ep.targetPort,
+                  replacement: '$1',
+                  action: 'keep',
+                },
+              ] else if std.isNumber(ep.targetPort) then [
+                {
+                  source_labels: ['__meta_kubernetes_pod_container_port_number'],
+                  separator: ';',
+                  regex: ep.targetPort,
+                  replacement: '$1',
+                  action: 'keep',
+                },
+              ] else error 'targetPort must be a string or integer'
+            else error 'could not set endpoint port selector'
+          ) + [
+
+            {
+              source_labels: ['__meta_kubernetes_endpoint_address_target_kind', '__meta_kubernetes_endpoint_address_target_name'],
+              separator: ';',
+              regex: 'Node;(.*)',
+              target_label: 'node',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_endpoint_address_target_kind', '__meta_kubernetes_endpoint_address_target_name'],
+              separator: ';',
+              regex: 'Pod;(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_namespace'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'namespace',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_service_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'service',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'pod',
+              replacement: '$1',
+              action: 'replace',
+            },
+            {
+              source_labels: ['__meta_kubernetes_pod_container_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'container',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+            // Relabel targetLabels from Service onto target.
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in svc.targetLabels
+          ] + [
+            {
+              source_labels: ['__meta_kubernetes_pod_label_' + common.sanitizeLabelName(l)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: l,
+              replacement: '$1',
+              action: 'replace',
+            }
+            for l in svc.podTargetLabels
+          ] + [
+
+            // Set job label
+            {
+              source_labels: ['__meta_kubernetes_service_name'],
+              separator: ';',
+              regex: '(.*)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+          ] + if svc.jobLabel != '' then [
+            {
+              source_labels: ['__meta_kubernetes_service_label_' + common.sanitizeLabelName(svc.jobLabel)],
+              separator: ';',
+              regex: '(.+)',
+              target_label: 'job',
+              replacement: '$1',
+              action: 'replace',
+            },
+
+          ] else
+            [] + (
+              if ep.port != '' then [
+                {
+                  target_label: 'endpoint',
+                  separator: ';',
+                  regex: '(.*)',
+                  replacement: ep.port,
+                  action: 'replace',
+                },
+              ] else if ep.targetPort != '' then [
+                {
+                  target_label: 'endpoint',
+                  separator: ';',
+                  regex: '(.*)',
+                  replacement: ep.targetPort,
+                  action: 'replace',
+                },
+              ] else error 'could not set endpoint label'
+            ) +
+
+            ep.relabelings,
+
+        kubernetes_sd_configs: [{
+          role: 'endpoints',
+          kubeconfig_file: '',
+          follow_redirects: ep.followRedirects,
+          namespaces: {
+            own_namespace: false,
+            names:
+              if svc.namespaceSelector.any then
+                []
+              else if std.length(svc.namespaceSelector.matchNames) == 0 then
+                [svc.namespace]
+              else svc.namespaceSelector.matchNames,
+          },
+        }],
+      }
+      for s in serviceProfilers
+      for i in std.range(0, std.length(s.endpoints) - 1)
+    ],
+  },
+}


### PR DESCRIPTION
### Summary

copilot:summary

### Walthrough

copilot:walkthrough

### Diffs

<details>
<summary>flux</summary>

```diff
===== networking.k8s.io/NetworkPolicy flux-system/image-automation-controller ======
diff --git a/tmp/argocd-diff1534440457/image-automation-controller-live.yaml b/tmp/argocd-diff1534440457/image-automation-controller
index 21388c6..76f6ea8 100644
--- a/tmp/argocd-diff1534440457/image-automation-controller-live.yaml
+++ b/tmp/argocd-diff1534440457/image-automation-controller
@@ -45,10 +45,25 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - port: http-prom
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: image-automation-controller
       app.kubernetes.io/name: flux
   policyTypes:
   - Egress
+  - Ingress
 status: {}

===== networking.k8s.io/NetworkPolicy flux-system/image-reflector-controller ======
diff --git a/tmp/argocd-diff475634327/image-reflector-controller-live.yaml b/tmp/argocd-diff475634327/image-reflector-controller
index 100498e..3842d2c 100644
--- a/tmp/argocd-diff475634327/image-reflector-controller-live.yaml
+++ b/tmp/argocd-diff475634327/image-reflector-controller
@@ -45,10 +45,25 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - port: http-prom
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: image-reflector-controller
       app.kubernetes.io/name: flux
   policyTypes:
   - Egress
+  - Ingress
 status: {}

===== networking.k8s.io/NetworkPolicy flux-system/source-controller ======
diff --git a/tmp/argocd-diff90098144/source-controller-live.yaml b/tmp/argocd-diff90098144/source-controller
index ca72bf3..ab8e481 100644
--- a/tmp/argocd-diff90098144/source-controller-live.yaml
+++ b/tmp/argocd-diff90098144/source-controller
@@ -45,10 +45,25 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - parca
+    ports:
+    - port: http-prom
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: source-controller
       app.kubernetes.io/name: flux
   policyTypes:
   - Egress
+  - Ingress
 status: {}
```

</details>

<details>
<summary>parca</summary>

```diff
===== /ConfigMap parca/parca ======
diff --git a/tmp/argocd-diff452085331/parca-live.yaml b/tmp/argocd-diff452085331/parca
index 573b1ee..063cc9c 100644
--- a/tmp/argocd-diff452085331/parca-live.yaml
+++ b/tmp/argocd-diff452085331/parca
@@ -6,6 +6,427 @@ data:
         "config":
           "directory": "/var/lib/parca"
         "type": "FILESYSTEM"
+    "scrape_configs":
+    - "job_name": "PodProfiler/parca/parca-agent/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "parca"
+          "own_namespace": false
+        "role": "pod"
+      "profiling_config": {}
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "observability"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "parca-agent"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_instance"
+      - "action": "keep"
+        "regex": "parca-agent"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_port_name"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "parca/parca-agent"
+        "separator": ";"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "source_labels":
+        - "__meta_kubernetes_pod_node_name"
+        "target_label": "instance"
+      - "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_version"
+        "target_label": "version"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
+    - "job_name": "PodProfiler/flux-system/image-automation-controller/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "flux-system"
+          "own_namespace": false
+        "role": "pod"
+      "profiling_config": {}
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "image-automation-controller"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "flux"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http-prom"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_port_name"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "flux-system/image-automation-controller"
+        "separator": ";"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http-prom"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "separator": "/"
+        "source_labels":
+        - "namespace"
+        - "pod"
+        "target_label": "instance"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
+    - "job_name": "PodProfiler/flux-system/image-reflector-controller/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "flux-system"
+          "own_namespace": false
+        "role": "pod"
+      "profiling_config": {}
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "image-reflector-controller"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "flux"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http-prom"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_port_name"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "flux-system/image-reflector-controller"
+        "separator": ";"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http-prom"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "separator": "/"
+        "source_labels":
+        - "namespace"
+        - "pod"
+        "target_label": "instance"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
+    - "job_name": "PodProfiler/flux-system/source-controller/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "flux-system"
+          "own_namespace": false
+        "role": "pod"
+      "profiling_config": {}
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "source-controller"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "flux"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http-prom"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_port_name"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "flux-system/source-controller"
+        "separator": ";"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http-prom"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "separator": "/"
+        "source_labels":
+        - "namespace"
+        - "pod"
+        "target_label": "instance"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
+    - "job_name": "ServiceProfiler/parca/parca/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "parca"
+          "own_namespace": false
+        "role": "endpoints"
+      "profiling_config":
+        "pprof_config":
+          "fgprof":
+            "enabled": true
+            "path": "/debug/pprof/fgprof"
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "observability"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "parca"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_instance"
+      - "action": "keep"
+        "regex": "parca"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_port_name"
+      - "action": "replace"
+        "regex": "Node;(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_address_target_kind"
+        - "__meta_kubernetes_endpoint_address_target_name"
+        "target_label": "node"
+      - "action": "replace"
+        "regex": "Pod;(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_address_target_kind"
+        - "__meta_kubernetes_endpoint_address_target_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_name"
+        "target_label": "service"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_name"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "separator": "/"
+        "source_labels":
+        - "namespace"
+        - "pod"
+        "target_label": "instance"
+      - "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_version"
+        "target_label": "version"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
 kind: ConfigMap
 metadata:
   annotations:

===== networking.k8s.io/NetworkPolicy parca/parca-agent ======
diff --git a/tmp/argocd-diff204236338/parca-agent-live.yaml b/tmp/argocd-diff204236338/parca-agent
index ad9550c..a89f2df 100644
--- a/tmp/argocd-diff204236338/parca-agent-live.yaml
+++ b/tmp/argocd-diff204236338/parca-agent
@@ -59,6 +59,12 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: prometheus
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: parca
     ports:
     - port: http
       protocol: TCP

===== policy/PodSecurityPolicy /parca ======
diff --git a/tmp/argocd-diff4225202183/parca-live.yaml b/tmp/argocd-diff4225202183/parca
index 4373f9d..bdb834f 100644
--- a/tmp/argocd-diff4225202183/parca-live.yaml
+++ b/tmp/argocd-diff4225202183/parca
@@ -2,7 +2,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca:policy/PodSecurityPolicy:parca/parca
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca:policy/PodSecurityPolicy:/parca
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"policy/v1beta1","kind":"PodSecurityPolicy","metadata":{"name":"parca"},"spec":{"allowPrivilegeEscalation":false,"fsGroup":{"ranges":[{"max":65535,"min":1}],"rule":"MustRunAs"},"requiredDropCapabilities":["ALL"],"runAsUser":{"rule":"MustRunAsNonRoot"},"seLinux":{"rule":"RunAsAny"},"supplementalGroups":{"ranges":[{"max":65535,"min":1}],"rule":"MustRunAs"},"volumes":["configMap","emptyDir","projected","secret","downwardAPI","persistentVolumeClaim"]}}
   managedFields:

===== tanka.dev/Environment /environments/scaleway-parca-demo ======

===== rbac.authorization.k8s.io/ClusterRole /parca ======
diff --git a/tmp/argocd-diff725224152/parca-live.yaml b/tmp/argocd-diff725224152/parca
index e69de29..f0a5119 100644
--- a/tmp/argocd-diff725224152/parca-live.yaml
+++ b/tmp/argocd-diff725224152/parca
@@ -0,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca:rbac.authorization.k8s.io/ClusterRole:parca/parca
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.17.0
+  name: parca
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

===== rbac.authorization.k8s.io/ClusterRoleBinding /parca ======
diff --git a/tmp/argocd-diff3807606404/parca-live.yaml b/tmp/argocd-diff3807606404/parca
index e69de29..81f7137 100644
--- a/tmp/argocd-diff3807606404/parca-live.yaml
+++ b/tmp/argocd-diff3807606404/parca
@@ -0,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca:rbac.authorization.k8s.io/ClusterRoleBinding:parca/parca
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.17.0
+  name: parca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: parca
+subjects:
+- kind: ServiceAccount
+  name: parca
+  namespace: parca
```

</details>

<details>
<summary>parca-devel</summary>

```diff

===== /ConfigMap parca-devel/parca-devel ======
diff --git a/tmp/argocd-diff447125182/parca-devel-live.yaml b/tmp/argocd-diff447125182/parca-devel
index 37bab08..340e9c3 100644
--- a/tmp/argocd-diff447125182/parca-devel-live.yaml
+++ b/tmp/argocd-diff447125182/parca-devel
@@ -6,6 +6,202 @@ data:
         "config":
           "directory": "/var/lib/parca"
         "type": "FILESYSTEM"
+    "scrape_configs":
+    - "job_name": "PodProfiler/parca-devel/parca-agent-devel/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "parca-devel"
+          "own_namespace": false
+        "role": "pod"
+      "profiling_config": {}
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "observability"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "parca-agent-devel"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_instance"
+      - "action": "keep"
+        "regex": "parca-agent"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_port_name"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "parca-devel/parca-agent-devel"
+        "separator": ";"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "source_labels":
+        - "__meta_kubernetes_pod_node_name"
+        "target_label": "instance"
+      - "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_version"
+        "target_label": "version"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
+    - "job_name": "ServiceProfiler/parca-devel/parca-devel/0"
+      "kubernetes_sd_configs":
+      - "follow_redirects": true
+        "kubeconfig_file": ""
+        "namespaces":
+          "names":
+          - "parca-devel"
+          "own_namespace": false
+        "role": "endpoints"
+      "profiling_config":
+        "pprof_config":
+          "fgprof":
+            "enabled": true
+            "path": "/debug/pprof/fgprof"
+      "relabel_configs":
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "job"
+        "target_label": "__tmp_prometheus_job_name"
+      - "action": "keep"
+        "regex": "observability"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_component"
+      - "action": "keep"
+        "regex": "parca-devel"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_instance"
+      - "action": "keep"
+        "regex": "parca"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_label_app_kubernetes_io_name"
+      - "action": "keep"
+        "regex": "http"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_port_name"
+      - "action": "replace"
+        "regex": "Node;(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_address_target_kind"
+        - "__meta_kubernetes_endpoint_address_target_name"
+        "target_label": "node"
+      - "action": "replace"
+        "regex": "Pod;(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_endpoint_address_target_kind"
+        - "__meta_kubernetes_endpoint_address_target_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_namespace"
+        "target_label": "namespace"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_name"
+        "target_label": "service"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_name"
+        "target_label": "pod"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_pod_container_name"
+        "target_label": "container"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "$1"
+        "separator": ";"
+        "source_labels":
+        - "__meta_kubernetes_service_name"
+        "target_label": "job"
+      - "action": "replace"
+        "regex": "(.*)"
+        "replacement": "http"
+        "separator": ";"
+        "target_label": "endpoint"
+      - "separator": "/"
+        "source_labels":
+        - "namespace"
+        - "pod"
+        "target_label": "instance"
+      - "source_labels":
+        - "__meta_kubernetes_pod_label_app_kubernetes_io_version"
+        "target_label": "version"
+      "scheme": "http"
+      "scrape_interval": "10s"
+      "scrape_timeout": "0s"
 kind: ConfigMap
 metadata:
   annotations:

===== networking.k8s.io/NetworkPolicy parca-devel/parca-agent-devel ======
diff --git a/tmp/argocd-diff2179907433/parca-agent-devel-live.yaml b/tmp/argocd-diff2179907433/parca-agent-devel
index bd2706d..f9840cd 100644
--- a/tmp/argocd-diff2179907433/parca-agent-devel-live.yaml
+++ b/tmp/argocd-diff2179907433/parca-agent-devel
@@ -44,6 +44,12 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: prometheus
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: parca
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: parca
     ports:
     - port: http
       protocol: TCP

===== policy/PodSecurityPolicy /parca-devel ======
diff --git a/tmp/argocd-diff2414691267/parca-devel-live.yaml b/tmp/argocd-diff2414691267/parca-devel
index 59fb8bd..c7eea89 100644
--- a/tmp/argocd-diff2414691267/parca-devel-live.yaml
+++ b/tmp/argocd-diff2414691267/parca-devel
@@ -2,7 +2,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca-devel:policy/PodSecurityPolicy:parca-devel/parca-devel
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca-devel:policy/PodSecurityPolicy:/parca-devel
   managedFields:
   - apiVersion: policy/v1beta1
     fieldsType: FieldsV1

===== rbac.authorization.k8s.io/ClusterRoleBinding /parca-devel ======
diff --git a/tmp/argocd-diff412900456/parca-devel-live.yaml b/tmp/argocd-diff412900456/parca-devel
index e69de29..d7bfd49 100644
--- a/tmp/argocd-diff412900456/parca-devel-live.yaml
+++ b/tmp/argocd-diff412900456/parca-devel
@@ -0,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca-devel:rbac.authorization.k8s.io/ClusterRoleBinding:parca-devel/parca-devel
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-devel
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: main-1685386783-1b1a3d6d
+  name: parca-devel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: parca-devel
+subjects:
+- kind: ServiceAccount
+  name: parca-devel
+  namespace: parca-devel

===== rbac.authorization.k8s.io/ClusterRole /parca-devel ======
diff --git a/tmp/argocd-diff1449561497/parca-devel-live.yaml b/tmp/argocd-diff1449561497/parca-devel
index e69de29..51603d5 100644
--- a/tmp/argocd-diff1449561497/parca-devel-live.yaml
+++ b/tmp/argocd-diff1449561497/parca-devel
@@ -0,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca-devel:rbac.authorization.k8s.io/ClusterRole:parca-devel/parca-devel
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-devel
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: main-1685386783-1b1a3d6d
+  name: parca-devel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

===== tanka.dev/Environment /environments/scaleway-parca-demo ======
```

</details>