### PR TITLE
fix(parca): configure NGINX ingress for GRPC

### DIFF
--- a/parca-devel/lib/parca.libsonnet
+++ b/parca-devel/lib/parca.libsonnet
@@ -225,6 +225,9 @@ function(params)
         name: $.config.name,
         namespace: $.config.namespace,
         labels: $.config.commonLabels,
+        annotations: {
+          'nginx.ingress.kubernetes.io/backend-protocol': 'GRPC',
+        },
       },
       spec: {
         ingressClassName: $.config.ingress.class,

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -47,6 +47,7 @@ function(params)
         labels: $.config.commonLabels,
         annotations: {
           'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
+          'nginx.ingress.kubernetes.io/backend-protocol': 'GRPC',
         },
       },
       spec: {


### PR DESCRIPTION
I was toying with this, it would allow to use the GRPC protocol to communicate with the demo:

```console
$ grpcurl demo.parca.dev:443 grpc.health.v1.Health/Check
{
  "status": "SERVING"
}
```

I saw this client failing with HTTP 415 (Unsupported Media Type), it's in Scaleway, but in another account I think (`parca-load` in Pyrra's account?):

```
51.15.51.214 - - [31/May/2023:19:55:34 +0000] "POST /parca.query.v1alpha1.QueryService/Query HTTP/2.0" 415 63 "-" "grpc-go-connect/1.1.0 (go1.18.10)" 98 0.001 [parca-parca-http] [] 100.64.2.183:7070 72 0.000 415 93c8ab7948a074a26b2435c8cb1808db
```

@metalmatze should it use GRPC-Web under `/api/` like the UI does? Or could we switch it to regular GRPC? 

<details>
<summary>diff</summary>

```diff
===== networking.k8s.io/Ingress parca/parca-grpc ======
diff --git a/tmp/argocd-diff2343086198/parca-grpc-live.yaml b/tmp/argocd-diff2343086198/parca-grpc
index e69de29..8c99a97 100644
--- a/tmp/argocd-diff2343086198/parca-grpc-live.yaml
+++ b/tmp/argocd-diff2343086198/parca-grpc
@@ -0,0 +1,72 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca:networking.k8s.io/Ingress:parca/parca-grpc
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.17.0
+  name: parca-grpc
+  namespace: parca
+spec:
+  rules:
+  - host: demo.parca.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /grpc.health.v1.Health
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /grpc.reflection.v1alpha.ServerReflection
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /parca.debuginfo.v1alpha1.DebuginfoService
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /parca.profilestore.v1alpha1.AgentsService
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /parca.profilestore.v1alpha1.ProfileStoreService
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /parca.query.v1alpha1.QueryService
+        pathType: Prefix
+      - backend:
+          service:
+            name: parca
+            port:
+              name: http
+        path: /parca.scrape.v1alpha1.ScrapeService
+        pathType: Prefix
+  tls:
+  - hosts:
+    - demo.parca.dev
+    secretName: demo-parca-dev-tls
```

</details>