### PR TITLE
Add parca-devel to Prometheus allowed namespaces

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -4,7 +4,7 @@ local prometheuses = [
   m.prometheus({
     prometheus+:: {
       name: 'parca',
-      namespaces: ['parca'],
+      namespaces: ['parca', 'parca-devel'],
     },
   }) {
     prometheus+: {
@@ -13,7 +13,7 @@ local prometheuses = [
           url: 'https://demo.pyrra.dev/prometheus/api/v1/write',
           writeRelabelConfigs: [{
             action: 'keep',
-            regex: 'parca/parca-agent',
+            regex: 'parca/parca-agent.*',
             sourceLabels: ['job'],
           }],
         }],


### PR DESCRIPTION
Prometheus is failing to list the pods in the `parca-devel` namespace with the following logs:
```
ts=2023-06-02T14:54:12.451Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:169: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:monitoring:prometheus-parca\" cannot list resource \"pods\" in API group \"\" in the namespace \"parca-devel\""
```

I think this PR should fix it now. 