### PR TITLE
Match job for parca-agent and parca-agent-devel

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -13,7 +13,7 @@ local prometheuses = [
           url: 'https://demo.pyrra.dev/prometheus/api/v1/write',
           writeRelabelConfigs: [{
             action: 'keep',
-            regex: 'parca/parca-agent.*',
+            regex: 'parca(|-devel)/parca-agent(|-devel)',
             sourceLabels: ['job'],
           }],
         }],


### PR DESCRIPTION
Right now, we only match the pod names, but we also need to have the regex for the namespace.
