### PR TITLE
fix(parca-devel): add path_prefix to profilingConfig

### DIFF
--- a/parca-devel/lib/parca.libsonnet
+++ b/parca-devel/lib/parca.libsonnet
@@ -118,6 +118,7 @@ local defaults = {
       endpoints: [{
         port: 'http',
         profilingConfig: {
+          path_prefix: 'devel',
           pprof_config: {
             fgprof: {
               enabled: true,


### PR DESCRIPTION
```diff
===== /ConfigMap parca-devel/parca-devel ======
diff --git a/tmp/argocd-diff3234137050/parca-devel-live.yaml b/tmp/argocd-diff3234137050/parca-devel
index ecf6cf1..402769f 100644
--- a/tmp/argocd-diff3234137050/parca-devel-live.yaml
+++ b/tmp/argocd-diff3234137050/parca-devel
@@ -324,6 +324,7 @@ data:
           "own_namespace": false
         "role": "endpoints"
       "profiling_config":
+        "path_prefix": "devel"
         "pprof_config":
           "fgprof":
             "delta": true
```