### PR TITLE
feat: add Contour Ingress controller

### DIFF
--- a/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
+++ b/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
@@ -28,13 +28,17 @@ local applications =
         },
       },
     },
+    u.newHelmApp(common {
+      name: 'cert-manager',
+      namespace: 'cert-manager',
+    }),
     u.newKustomizeApp(common {
       name: 'cluster-config',
       namespace: 'default',
     }),
-    u.newHelmApp(common {
-      name: 'cert-manager',
-      namespace: 'cert-manager',
+    u.newKustomizeApp(common {
+      name: 'contour',
+      namespace: 'projectcontour',
     }),
     u.newKustomizeApp(common {
       name: 'flux',

--- a/cert-manager/templates/cluster-issuer.yaml
+++ b/cert-manager/templates/cluster-issuer.yaml
@@ -13,4 +13,7 @@ spec:
     solvers:
     - http01:
         ingress:
+          class: contour
+    - http01:
+        ingress:
           class: nginx

--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -51,3 +51,12 @@ metadata:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: projectcontour
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/contour/base/kustomization.yaml
+++ b/contour/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: projectcontour
+resources:
+- https://raw.githubusercontent.com/projectcontour/contour/29304312ceca63b8dfbb6c359dcc5cf006e868cc/examples/render/contour-deployment.yaml # v1.25.0
+
+labels:
+- pairs:
+    app.kubernetes.io/part-of: projectcontour
+  includeSelectors: true
+
+# Ignoring deprecation for now
+# https://github.com/kubernetes-sigs/kustomize/issues/5049
+patchesStrategicMerge:
+- patches/delete_namespace.yaml
+- patches/configure_contour.yaml
+- patches/set_resources_limits_requests.yaml
+- patches/set_service_annotations.yaml
+
+replicas:
+- name: contour
+  count: 1
+- name: envoy
+  count: 1

--- a/contour/base/networkpolicies.yaml
+++ b/contour/base/networkpolicies.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: contour
+spec:
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: envoy
+      port: xds
+  podSelector:
+    matchLabels:
+      app: contour
+  policyTypes:
+  - Egress
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: contour-certgen
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app: contour-certgen
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: envoy
+spec:
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - port: http
+    - port: https
+  podSelector:
+    matchLabels:
+      app: envoy
+  policyTypes:
+  - Egress
+  - Ingress

--- a/contour/base/patches/configure_contour.yaml
+++ b/contour/base/patches/configure_contour.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  template:
+    spec:
+      containers:
+      - name: contour
+        args:
+        # Original args from
+        # https://github.com/projectcontour/contour/blob/main/examples/contour/03-contour.yaml
+        - serve
+        - --incluster
+        - --xds-address=0.0.0.0
+        - --xds-port=8001
+        - --contour-cafile=/certs/ca.crt
+        - --contour-cert-file=/certs/tls.crt
+        - --contour-key-file=/certs/tls.key
+        - --config-path=/config/contour.yaml
+        # Enable PROXY protocol
+        # https://projectcontour.io/docs/latest/guides/proxy-proto/
+        - --use-proxy-protocol

--- a/contour/base/patches/delete_namespace.yaml
+++ b/contour/base/patches/delete_namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: projectcontour
+$patch: delete

--- a/contour/base/patches/set_resources_limits_requests.yaml
+++ b/contour/base/patches/set_resources_limits_requests.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  template:
+    spec:
+      containers:
+      - name: contour
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  namespace: projectcontour
+spec:
+  template:
+    spec:
+      containers:
+      - name: shutdown-manager
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      - name: envoy
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/contour/base/patches/set_service_annotations.yaml
+++ b/contour/base/patches/set_service_annotations.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+  namespace: projectcontour
+  annotations:
+    service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
+    service.beta.kubernetes.io/scw-loadbalancer-use-hostname: "true"
+    service.beta.kubernetes.io/scw-loadbalancer-zone: "nl-ams-2"
+    $patch: replace

--- a/contour/overlays/scaleway-parca-demo/kustomization.yaml
+++ b/contour/overlays/scaleway-parca-demo/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/renovate.json
+++ b/renovate.json
@@ -61,9 +61,20 @@
       "description": "Pin Kustomize bases digests - https://github.com/renovatebot/renovate/issues/7915",
       "fileMatch": ["(^|/)kustomization.yaml$"],
       "matchStrings": [
-          "- github\\.com\\/(?<depName>[^/]+?\\/[^/]*?)\\/.*\\?ref=(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>.+)"
+          "\\s*-\\s+github\\.com\\/(?<depName>[^/]+?\\/[^/]*?)\\/.*\\?ref=(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>.+)"
       ],
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "description": "Update Kustomize remote bases based on raw Github user content",
+      "fileMatch": [
+        "(^|/)kustomization\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*-\\s+https:\\/\\/raw\\.githubusercontent\\.com\\/(?<depName>.+?\\/.+?)\\/(?<currentDigest>[a-f0-9]{40}?)\\/.+\\.yaml # (?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
Opening for the record, blocked by:

> Contour configures Envoy to automatically convert [gRPC-Web](https://github.com/grpc/grpc-web) HTTP/1 requests to gRPC over HTTP/2 RPC calls to an upstream service. This is a convenience addition to make usage of gRPC web application client libraries and the like easier.
> 
> Note that you still must provide configuration of the upstream protocol to have gRPC-Web requests converted to gRPC to the upstream app. If your upstream application does not in fact support gRPC, you may get a protocol error. In that case, please see [this issue](https://togithub.com/projectcontour/contour/issues/4290).

Related to #43