### PR TITLE
fix(monitoring): move namespace to cluster-config

### DIFF
--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -46,6 +46,16 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: parca-analytics
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: parca-devel
   labels:
     pod-security.kubernetes.io/audit: privileged

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -28,18 +28,10 @@ local prometheuses = [
     prometheus+:: {
       name: 'parca-analytics',
       namespace: 'parca-analytics',
-      namespaces: ['parca-analytics'],
+      namespaces: [],
     },
   }) {
     local p = self,
-
-    namespace: {
-      apiVersion: 'v1',
-      kind: 'Namespace',
-      metadata: {
-        name: 'parca-analytics',
-      },
-    },
 
     ingressRemoteWrite: {
       apiVersion: 'networking.k8s.io/v1',

--- a/monitoring/lib/prometheus.libsonnet
+++ b/monitoring/lib/prometheus.libsonnet
@@ -49,10 +49,34 @@ function(params={}) (
         },
         spec: {
           egress: [{}],
+          ingress: [{
+            from: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    'kubernetes.io/metadata.name': 'ingress-nginx',
+                  },
+                },
+                podSelector: {
+                  matchLabels: {
+                    'app.kubernetes.io/name': 'ingress-nginx',
+                    'app.kubernetes.io/component': 'controller',
+                    'app.kubernetes.io/instance': 'ingress-nginx',
+                  },
+                },
+              },
+            ],
+            ports: [{
+              port: 'web',
+            }],
+          }],
           podSelector: {
             matchLabels: p._config.selectorLabels,
           },
-          policyTypes: ['Egress'],
+          policyTypes: [
+            'Egress',
+            'Ingress',
+          ],
         },
       },
 


### PR DESCRIPTION
This allow to decouple the lifecycles of the namespace and the application, when we remove the application, we do not necessarily want to remove the namespace and everything in it.

Also:

- Explicitly allow traffic from ingress-nginx (it worked as we do not have a deny default policy for now)
- Remove RBAC on `parca-analytics` namespace as this instance is not used to monitor the namespace  


<details>
<summary>cluster-config</summary>

```diff
===== /Namespace /parca-analytics ======
diff --git a/tmp/argocd-diff596013952/parca-analytics-live.yaml b/tmp/argocd-diff596013952/parca-analytics
index e69de29..dd9df17 100644
--- a/tmp/argocd-diff596013952/parca-analytics-live.yaml
+++ b/tmp/argocd-diff596013952/parca-analytics
@@ -0,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: scaleway-parca-demo-cluster-config:/Namespace:default/parca-analytics
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
+  name: parca-analytics
```

</details>

<details>
<summary>monitoring</summary>

```diff

===== /Namespace /parca-analytics ======
diff --git a/tmp/argocd-diff2258837151/parca-analytics-live.yaml b/tmp/argocd-diff2258837151/parca-analytics
index e6b8ef8..e69de29 100644
--- a/tmp/argocd-diff2258837151/parca-analytics-live.yaml
+++ b/tmp/argocd-diff2258837151/parca-analytics
@@ -1,25 +0,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:/Namespace:monitoring/parca-analytics
-  labels:
-    kubernetes.io/metadata.name: parca-analytics
-  managedFields:
-  - apiVersion: v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          f:argocd.argoproj.io/tracking-id: {}
-    manager: argocd-controller
-    operation: Apply
-    time: "2023-06-28T08:13:53Z"
-  name: parca-analytics
-  resourceVersion: "24253674159"
-  uid: d66755b7-638f-42bd-9d13-b1215ca0568f
-spec:
-  finalizers:
-  - kubernetes
-status:
-  phase: Active

===== networking.k8s.io/NetworkPolicy monitoring/prometheus-parca ======
diff --git a/tmp/argocd-diff3751982605/prometheus-parca-live.yaml b/tmp/argocd-diff3751982605/prometheus-parca
index 639802a..c024dd8 100644
--- a/tmp/argocd-diff3751982605/prometheus-parca-live.yaml
+++ b/tmp/argocd-diff3751982605/prometheus-parca
@@ -64,6 +64,19 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: ingress-nginx
+          app.kubernetes.io/name: ingress-nginx
+    ports:
+    - port: web
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus
@@ -72,4 +85,5 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
   policyTypes:
   - Egress
+  - Ingress
 status: {}

===== networking.k8s.io/NetworkPolicy parca-analytics/prometheus-parca-analytics ======
diff --git a/tmp/argocd-diff86912120/prometheus-parca-analytics-live.yaml b/tmp/argocd-diff86912120/prometheus-parca-analytics
index 9652d03..d4ce1ce 100644
--- a/tmp/argocd-diff86912120/prometheus-parca-analytics-live.yaml
+++ b/tmp/argocd-diff86912120/prometheus-parca-analytics
@@ -37,6 +37,19 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: ingress-nginx
+          app.kubernetes.io/name: ingress-nginx
+    ports:
+    - port: web
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus
@@ -45,4 +58,5 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
   policyTypes:
   - Egress
+  - Ingress
 status: {}

===== rbac.authorization.k8s.io/Role parca-analytics/prometheus-parca-analytics ======
diff --git a/tmp/argocd-diff2993434737/prometheus-parca-analytics-live.yaml b/tmp/argocd-diff2993434737/prometheus-parca-analytics
index 6df47fe..e69de29 100644
--- a/tmp/argocd-diff2993434737/prometheus-parca-analytics-live.yaml
+++ b/tmp/argocd-diff2993434737/prometheus-parca-analytics
@@ -1,59 +0,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:rbac.authorization.k8s.io/Role:parca-analytics/prometheus-parca-analytics
-  labels:
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/instance: parca-analytics
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.45.0
-  managedFields:
-  - apiVersion: rbac.authorization.k8s.io/v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          f:argocd.argoproj.io/tracking-id: {}
-        f:labels:
-          f:app.kubernetes.io/component: {}
-          f:app.kubernetes.io/instance: {}
-          f:app.kubernetes.io/name: {}
-          f:app.kubernetes.io/part-of: {}
-          f:app.kubernetes.io/version: {}
-      f:rules: {}
-    manager: argocd-controller
-    operation: Apply
-    time: "2023-06-28T08:13:56Z"
-  name: prometheus-parca-analytics
-  namespace: parca-analytics
-  resourceVersion: "24253674616"
-  uid: b804fd69-8d96-45aa-a036-80fe87cb6816
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch

===== rbac.authorization.k8s.io/RoleBinding parca-analytics/prometheus-parca-analytics ======
diff --git a/tmp/argocd-diff2193891892/prometheus-parca-analytics-live.yaml b/tmp/argocd-diff2193891892/prometheus-parca-analytics
index 9c7b663..e69de29 100644
--- a/tmp/argocd-diff2193891892/prometheus-parca-analytics-live.yaml
+++ b/tmp/argocd-diff2193891892/prometheus-parca-analytics
@@ -1,41 +0,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:rbac.authorization.k8s.io/RoleBinding:parca-analytics/prometheus-parca-analytics
-  labels:
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/instance: parca-analytics
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.45.0
-  managedFields:
-  - apiVersion: rbac.authorization.k8s.io/v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          f:argocd.argoproj.io/tracking-id: {}
-        f:labels:
-          f:app.kubernetes.io/component: {}
-          f:app.kubernetes.io/instance: {}
-          f:app.kubernetes.io/name: {}
-          f:app.kubernetes.io/part-of: {}
-          f:app.kubernetes.io/version: {}
-      f:roleRef: {}
-      f:subjects: {}
-    manager: argocd-controller
-    operation: Apply
-    time: "2023-06-28T08:30:40Z"
-  name: prometheus-parca-analytics
-  namespace: parca-analytics
-  resourceVersion: "24253846494"
-  uid: 973789a9-3432-49c6-bc6d-8543e0fcf749
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-parca-analytics
-subjects:
-- kind: ServiceAccount
-  name: prometheus-parca-analytics
-  namespace: parca-analytics

===== tanka.dev/Environment /environments/scaleway-parca-demo ======
```

</details>