### PR TITLE
fix(cert-manager): use ingressClassName

### DIFF
--- a/cert-manager/templates/cluster-issuer.yaml
+++ b/cert-manager/templates/cluster-issuer.yaml
@@ -13,4 +13,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          ingressClassName: nginx


### PR DESCRIPTION
Follow up to #51 

```diff
===== cert-manager.io/ClusterIssuer /letsencrypt-prod ======
diff --git a/tmp/argocd-diff3189961692/letsencrypt-prod-live.yaml b/tmp/argocd-diff3189961692/letsencrypt-prod
index 9b34f94..0be228c 100644
--- a/tmp/argocd-diff3189961692/letsencrypt-prod-live.yaml
+++ b/tmp/argocd-diff3189961692/letsencrypt-prod
@@ -59,7 +59,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          ingressClassName: nginx
 status:
   acme:
     lastPrivateKeyHash: Otn/Woxmy3cJrMGep4LcbNDVX3JMjUrqdqiWzEbFeXU=
```