### PR TITLE
fix(monitoring): set prometheus seccompProfile

### DIFF
--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -33,6 +33,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace

--- a/monitoring/lib/prometheus.libsonnet
+++ b/monitoring/lib/prometheus.libsonnet
@@ -36,6 +36,15 @@ function(params={}) (
     prometheus+: {
       local p = self,
 
+      prometheus+: {
+        spec+: {
+          securityContext+: {
+            // TODO: contribute seccompProfile to upstream
+            seccompProfile+: { type: 'RuntimeDefault' },
+          },
+        },
+      },
+
       // Hide
       prometheusRule:: {},
 


### PR DESCRIPTION
```diff
===== monitoring.coreos.com/Prometheus monitoring/parca ======
diff --git a/tmp/argocd-diff267468122/parca-live.yaml b/tmp/argocd-diff267468122/parca
index e4a6b86..c638d73 100644
--- a/tmp/argocd-diff267468122/parca-live.yaml
+++ b/tmp/argocd-diff267468122/parca
@@ -210,6 +210,8 @@ spec:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccountName: prometheus-parca
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}

===== monitoring.coreos.com/Prometheus parca-analytics/parca-analytics ======
diff --git a/tmp/argocd-diff1527353001/parca-analytics-live.yaml b/tmp/argocd-diff1527353001/parca-analytics
index 73de863..34d6ce9 100644
--- a/tmp/argocd-diff1527353001/parca-analytics-live.yaml
+++ b/tmp/argocd-diff1527353001/parca-analytics
@@ -144,6 +144,8 @@ spec:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccountName: prometheus-parca-analytics
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}

===== tanka.dev/Environment /environments/scaleway-parca-demo ======

```