### PR TITLE
fix(ingress-nginx): enforce restricted PSA

### DIFF
--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -13,6 +13,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace
@@ -28,6 +33,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-nginx
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace

--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -16,3 +16,29 @@ ingress-nginx:
       requests:
         cpu: 100m
         memory: 256Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+       drop:
+       - ALL
+       add:
+       - NET_BIND_SERVICE
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    admissionWebhooks:
+      createSecretJob:
+        securityContext:
+          capabilities:
+           drop:
+           - ALL
+      patchWebhookJob:
+        securityContext:
+          capabilities:
+           drop:
+           - ALL
+      patch:
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
<details>
<summary>cluster-config</summary>

```diff
===== /Namespace /cert-manager ======
diff --git a/tmp/argocd-diff3484008869/cert-manager-live.yaml b/tmp/argocd-diff3484008869/cert-manager
index 8a6091b..e6438de 100644
--- a/tmp/argocd-diff3484008869/cert-manager-live.yaml
+++ b/tmp/argocd-diff3484008869/cert-manager
@@ -7,6 +7,10 @@ metadata:
       {"apiVersion":"v1","kind":"Namespace","metadata":{"name":"cert-manager"}}
   labels:
     kubernetes.io/metadata.name: cert-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
   managedFields:
   - apiVersion: v1
     fieldsType: FieldsV1

===== /Namespace /ingress-nginx ======
diff --git a/tmp/argocd-diff904452865/ingress-nginx-live.yaml b/tmp/argocd-diff904452865/ingress-nginx
index 22936de..48e09b4 100644
--- a/tmp/argocd-diff904452865/ingress-nginx-live.yaml
+++ b/tmp/argocd-diff904452865/ingress-nginx
@@ -7,6 +7,10 @@ metadata:
       {"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ingress-nginx"}}
   labels:
     kubernetes.io/metadata.name: ingress-nginx
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
   managedFields:
   - apiVersion: v1
     fieldsType: FieldsV1
```

</details>

<details>
<summary>ingress-nginx</summary>

```diff
===== apps/Deployment ingress-nginx/ingress-nginx-controller ======
diff --git a/tmp/argocd-diff1984674952/ingress-nginx-controller-live.yaml b/tmp/argocd-diff1984674952/ingress-nginx-controller
index 64d1dd5..231b54a 100644
--- a/tmp/argocd-diff1984674952/ingress-nginx-controller-live.yaml
+++ b/tmp/argocd-diff1984674952/ingress-nginx-controller
@@ -400,7 +400,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -418,7 +418,10 @@ spec:
         kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: ingress-nginx
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 300
```

</details>