### PR TITLE
fix(monitoring): add seccompProfile to prometheus-operator

### DIFF
--- a/monitoring/lib/prometheus-operator.libsonnet
+++ b/monitoring/lib/prometheus-operator.libsonnet
@@ -13,6 +13,21 @@ function(params={}) (
     prometheusOperator+: {
       local po = self,
 
+      deployment+: {
+        spec+: {
+          template+: {
+            spec+: {
+              securityContext+: {
+                seccompProfile+: {
+                  // TODO: contribute seccompProfile to upstream
+                  type: 'RuntimeDefault',
+                },
+              },
+            },
+          },
+        },
+      },
+
       // Hide
       prometheusRule:: {},
 


### PR DESCRIPTION
```diff
===== apps/Deployment monitoring/prometheus-operator ======
diff --git a/tmp/argocd-diff2538922502/prometheus-operator-live.yaml b/tmp/argocd-diff2538922502/prometheus-operator
index 66ea265..b745e29 100644
--- a/tmp/argocd-diff2538922502/prometheus-operator-live.yaml
+++ b/tmp/argocd-diff2538922502/prometheus-operator
@@ -311,6 +311,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: prometheus-operator
       serviceAccountName: prometheus-operator
       terminationGracePeriodSeconds: 30

===== tanka.dev/Environment /environments/scaleway-parca-demo ======
```