### PR TITLE
ci(kubeconform): bump Kubernetes schemas to v1.27.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ env:
   KUBECONFORM_VERSION: v0.6.2
   # Must match target Kubernetes cluster minor version
   # https://github.com/parca-dev/demo-infrastructure/blob/main/scaleway/main.tf
-  KUBERNETES_VERSION: 1.25.5
+  KUBERNETES_VERSION: 1.27.1
   # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   KUSTOMIZE_VERSION: kustomize/v5.1.0
 


### PR DESCRIPTION
I had in mind to use Talos in Civo which has v1.25.5 only, but it does not support Cilium yet. So switching to k3s.