### PR TITLE
fix(argocd): avoid duplicate policyTypes in redis netpol

### DIFF
--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -32,9 +32,11 @@ patches:
     - op: add
       path: /spec/egress
       value: [{}]
-    - op: add
-      path: /spec/policyTypes/-
-      value: Egress
+    - op: replace
+      path: /spec/policyTypes
+      value:
+      - Ingress
+      - Egress
 
 configMapGenerator:
 - name: argocd-cmd-params-cm


### PR DESCRIPTION
```diff
===== networking.k8s.io/NetworkPolicy argocd/argocd-redis-network-policy ======
diff --git a/tmp/argocd-diff3949817150/argocd-redis-network-policy-live.yaml b/tmp/argocd-diff3949817150/argocd-redis-network-policy
index 8b4c79f..2b6056b 100644
--- a/tmp/argocd-diff3949817150/argocd-redis-network-policy-live.yaml
+++ b/tmp/argocd-diff3949817150/argocd-redis-network-policy
@@ -36,11 +36,7 @@ metadata:
   uid: fc18568b-f133-4d2e-8119-b47c1f8d4e83
 spec:
   egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
+  - {}
   ingress:
   - from:
     - podSelector:
```