### PR TITLE
feat!(argocd): migrate argocd to its own DNS hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 This is our [demo.parca.dev](https://demo.parca.dev) cluster configuration.
 
-* argocd - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-argocd)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-argocd)
-* argocd-applications - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-argocd-applications)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-argocd-applications)
-* cert-manager - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-cert-manager)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-cert-manager)
-* cluster-config - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-cluster-config)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-cluster-config)
-* flux - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-flux)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-flux)
-* grafana - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-grafana)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-grafana)
-* ingress-nginx - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-ingress-nginx)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-ingress-nginx)
-* monitoring - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-monitoring)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-monitoring)
-* oauth2-proxy - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-oauth2-proxy)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-oauth2-proxy)
-* parca - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-parca)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-parca)
-* parca-devel - [![App Status](https://demo.parca.dev/argo-cd/api/badge?name=scaleway-parca-demo-parca-devel)](https://demo.parca.dev/argo-cd/applications/scaleway-parca-demo-parca-devel)
+* argocd - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-argocd)](https://argocd.parca.dev/applications/scaleway-parca-demo-argocd)
+* argocd-applications - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-argocd-applications)](https://argocd.parca.dev/applications/scaleway-parca-demo-argocd-applications)
+* cert-manager - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-cert-manager)](https://argocd.parca.dev/applications/scaleway-parca-demo-cert-manager)
+* cluster-config - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-cluster-config)](https://argocd.parca.dev/applications/scaleway-parca-demo-cluster-config)
+* flux - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-flux)](https://argocd.parca.dev/applications/scaleway-parca-demo-flux)
+* grafana - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-grafana)](https://argocd.parca.dev/applications/scaleway-parca-demo-grafana)
+* ingress-nginx - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-ingress-nginx)](https://argocd.parca.dev/applications/scaleway-parca-demo-ingress-nginx)
+* monitoring - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-monitoring)](https://argocd.parca.dev/applications/scaleway-parca-demo-monitoring)
+* oauth2-proxy - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-oauth2-proxy)](https://argocd.parca.dev/applications/scaleway-parca-demo-oauth2-proxy)
+* parca - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-parca)](https://argocd.parca.dev/applications/scaleway-parca-demo-parca)
+* parca-devel - [![App Status](https://argocd.parca.dev/api/badge?name=scaleway-parca-demo-parca-devel)](https://argocd.parca.dev/applications/scaleway-parca-demo-parca-devel)
 
 Ask in one of our channels to be invited to the Scaleway Organization.
 Once you have access you can download the kubeconfig via the UI.
@@ -147,7 +147,7 @@ ${COMMAND} | kubeconform \
 
 ## Continuous deployment
 
-* Our [Argo CD](https://argoproj.github.io/cd/) instance is available at: https://demo.parca.dev/argo-cd (see also [argocd/](argocd))
+* Our [Argo CD](https://argoproj.github.io/cd/) instance is available at: https://argocd.parca.dev (see also [argocd/](argocd))
 * Argo CD Applications are configured under [argocd-applications/](argocd-applications)
 * [Flux](https://fluxcd.io/) is used to automate the Parca server and agent image updates (see [flux/](flux))
 * [Renovate](https://docs.renovatebot.com/) is used to update community dependencies (see [GitHub App](https://github.com/apps/renovate) and [renovate.json](renovate.json))

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -8,7 +8,7 @@ See [Operator Manual - Argo CD](https://argo-cd.readthedocs.io/en/stable/operato
 2. Login with:
 
    ```shell
-   argocd login demo.parca.dev --grpc-web-root-path /argo-cd --sso
+   argocd login argocd.parca.dev --grpc-web --sso
    ```
 
 3. Optional, validate the authentication was successful with: `argocd account get-user-info`

--- a/argocd/overlays/civo-demo/argocd-server-ingress.yaml
+++ b/argocd/overlays/civo-demo/argocd-server-ingress.yaml
@@ -2,12 +2,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
   labels:
     app.kubernetes.io/part-of: argocd
 spec:
   ingressClassName: nginx
   rules:
-  - host: demo.parca.dev
+  - host: argocd.parca.dev
     http:
       paths:
       - backend:
@@ -15,5 +17,9 @@ spec:
             name: argocd-server
             port:
               name: http
-        path: /argo-cd
+        path: /
         pathType: Prefix
+  tls:
+  - hosts:
+    - argocd.parca.dev
+    secretName: argocd.parca.dev

--- a/argocd/overlays/civo-demo/kustomization.yaml
+++ b/argocd/overlays/civo-demo/kustomization.yaml
@@ -6,24 +6,12 @@ resources:
 - ../../base
 - argocd-server-ingress.yaml
 
-patches:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: argocd-server
-  patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --rootpath=/argo-cd
-
-
 configMapGenerator:
 - name: argocd-cm
   namespace: argocd
   behavior: merge
   literals:
-  - url=https://demo.parca.dev/argo-cd
+  - url=https://argocd.parca.dev
   files:
   - dex.config=files/dex.config.yaml
 - name: argocd-rbac-cm

--- a/argocd/overlays/scaleway-parca-demo/argocd-server-ingress.yaml
+++ b/argocd/overlays/scaleway-parca-demo/argocd-server-ingress.yaml
@@ -2,12 +2,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
   labels:
     app.kubernetes.io/part-of: argocd
 spec:
   ingressClassName: nginx
   rules:
-  - host: demo.parca.dev
+  - host: argocd.parca.dev
     http:
       paths:
       - backend:
@@ -15,5 +17,9 @@ spec:
             name: argocd-server
             port:
               name: http
-        path: /argo-cd
+        path: /
         pathType: Prefix
+  tls:
+  - hosts:
+    - argocd.parca.dev
+    secretName: argocd.parca.dev

--- a/argocd/overlays/scaleway-parca-demo/kustomization.yaml
+++ b/argocd/overlays/scaleway-parca-demo/kustomization.yaml
@@ -6,24 +6,12 @@ resources:
 - ../../base
 - argocd-server-ingress.yaml
 
-patches:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: argocd-server
-  patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --rootpath=/argo-cd
-
-
 configMapGenerator:
 - name: argocd-cm
   namespace: argocd
   behavior: merge
   literals:
-  - url=https://demo.parca.dev/argo-cd
+  - url=https://argocd.parca.dev
   files:
   - dex.config=files/dex.config.yaml
 - name: argocd-rbac-cm


### PR DESCRIPTION
Using `demo.parca.dev` creates an awkward dependencies with Parca's certificate. Using its own domain should make bootstrapping a new cluster simpler.

<details>
<summary>diff</summary>

```diff
===== /ConfigMap argocd/argocd-cm ======
diff --git a/tmp/argocd-diff1252284104/argocd-cm-live.yaml b/tmp/argocd-diff1252284104/argocd-cm
index 49a74c8..af0ddc9 100644
--- a/tmp/argocd-diff1252284104/argocd-cm-live.yaml
+++ b/tmp/argocd-diff1252284104/argocd-cm
@@ -23,7 +23,7 @@ data:
       clusters:
       - '*'
   statusbadge.enabled: "true"
-  url: https://demo.parca.dev/argo-cd
+  url: https://argocd.parca.dev
   users.anonymous.enabled: "true"
 kind: ConfigMap
 metadata:

===== apps/Deployment argocd/argocd-server ======
diff --git a/tmp/argocd-diff4139013551/argocd-server-live.yaml b/tmp/argocd-diff4139013551/argocd-server
index 4f07cb8..d16c09b 100644
--- a/tmp/argocd-diff4139013551/argocd-server-live.yaml
+++ b/tmp/argocd-diff4139013551/argocd-server
@@ -660,7 +660,6 @@ spec:
       containers:
       - args:
         - /usr/local/bin/argocd-server
-        - --rootpath=/argo-cd
         env:
         - name: ARGOCD_SERVER_INSECURE
           valueFrom:

===== networking.k8s.io/Ingress argocd/argocd-server ======
diff --git a/tmp/argocd-diff1467609054/argocd-server-live.yaml b/tmp/argocd-diff1467609054/argocd-server
index 197ce9f..d9d2675 100644
--- a/tmp/argocd-diff1467609054/argocd-server-live.yaml
+++ b/tmp/argocd-diff1467609054/argocd-server
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   annotations:
     argocd.argoproj.io/tracking-id: scaleway-parca-demo-argocd:networking.k8s.io/Ingress:argocd/argocd-server
+    cert-manager.io/cluster-issuer: letsencrypt-prod
   generation: 5
   labels:
     app.kubernetes.io/part-of: argocd
@@ -50,7 +52,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: demo.parca.dev
+  - host: argocd.parca.dev
     http:
       paths:
       - backend:
@@ -58,7 +60,7 @@ spec:
             name: argocd-server
             port:
               name: http
-        path: /argo-cd
+        path: /
         pathType: Prefix
+  tls:
+  - hosts:
+    - argocd.parca.dev
+    secretName: argocd.parca.dev
 status:
   loadBalancer:
```

</details>