### PR TITLE
fix(ingress-nginx): restore helm hooks netpol

### DIFF
--- a/ingress-nginx/templates/admission-webhooks-networkpolicy.yaml
+++ b/ingress-nginx/templates/admission-webhooks-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-admission
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/component: admission-webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
Oops it had slip my mind what the netpol was for