### PR TITLE
revert: remove docker digest from labels

### DIFF
--- a/grafana/lib/grafana.libsonnet
+++ b/grafana/lib/grafana.libsonnet
@@ -8,7 +8,7 @@ local defaults = {
   ],
   namespace: 'grafana',
   // renovate: datasource=docker depName=docker.io/grafana/grafana
-  version: '10.1.2@sha256:63854c5592bab6c7b8ac2ceb35b420925465eb24ef05f2402e4cb805253efb46',
+  version: '10.1.2',
   replicas: 1,
   commonLabels+: {
     'app.kubernetes.io/component': 'observability',

--- a/parca/lib/parca-agent.libsonnet
+++ b/parca/lib/parca-agent.libsonnet
@@ -3,7 +3,7 @@ local pa = import 'github.com/parca-dev/parca-agent/deploy/lib/parca-agent/parca
 local defaults = {
   namespace: 'parca',
   // renovate: datasource=docker depName=ghcr.io/parca-dev/parca-agent
-  version: 'v0.25.0@sha256:ada2e25244758dbc62d4e8e778c5eddb013ad1199a0236c0fe8975d83448508c',
+  version: 'v0.25.0',
   image: 'ghcr.io/parca-dev/parca-agent:' + self.version,
   stores: ['parca.%s.svc.cluster.local:7070' % self.namespace],
   insecure: true,

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -3,7 +3,7 @@ local p = import 'github.com/parca-dev/parca/deploy/lib/parca/parca.libsonnet';
 local defaults = {
   namespace: 'parca',
   // renovate: datasource=docker depName=ghcr.io/parca-dev/parca
-  version: 'v0.18.0@sha256:39fc8bd1432ca0cf424ead49bb22fb4d99b767960220de86a59237e4b3fca901',
+  version: 'v0.18.0',
   image: 'ghcr.io/parca-dev/parca:' + self.version,
   replicas: 1,
   ingress: {


### PR DESCRIPTION
```
metadata.labels: Invalid value: "10.1.2@sha256:63854c5592bab6c7b8ac2ceb35b420925465eb24ef05f2402e4cb805253efb46": must be no more than 63 characters, metadata.labels: Invalid value: "10.1.2@sha256:63854c5592bab6c7b8ac2ceb35b420925465eb24ef05f2402e4cb805253efb46": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

This reverts commit e9c99703b82fd9d06daf4bddebd7132f5278bfed.