### PR TITLE
fix(cert-manager): omit empty preferredChain

### DIFF
--- a/cert-manager/templates/cluster-issuer.yaml
+++ b/cert-manager/templates/cluster-issuer.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   acme:
     email: parca-team@googlegroups.com
-    preferredChain: ""
     privateKeySecretRef:
       name: letsencrypt-prod
     server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
This field is now optional and omitted when empty, which creates a diff in Argo CD.