### PR TITLE
fix(parca-agent): bump memory to 1GiB / remove BPF verbose logging

### DIFF
--- a/parca-devel/lib/parca-agent.libsonnet
+++ b/parca-devel/lib/parca-agent.libsonnet
@@ -13,11 +13,11 @@ local defaults = {
   resources: {
     limits: {
       cpu: '100m',
-      memory: '512Mi',
+      memory: '1Gi',
     },
     requests: {
       cpu: '10m',
-      memory: '128Mi',
+      memory: '1Gi',
     },
   },
   podMonitor: true,
@@ -31,15 +31,6 @@ function(params={})
       spec+: {
         template+: {
           spec+: {
-            containers: [
-              if c.name == 'parca-agent' then c {
-                // TODO: Make it easy to pass extra args upstream.
-                args+: [
-                  '--bpf-verbose-logging',
-                ],
-              } else c
-              for c in super.containers
-            ],
             priorityClassName: 'system-node-critical',
           },
         },

--- a/parca/lib/parca-agent.libsonnet
+++ b/parca/lib/parca-agent.libsonnet
@@ -12,11 +12,11 @@ local defaults = {
   resources: {
     limits: {
       cpu: '100m',
-      memory: '512Mi',
+      memory: '1Gi',
     },
     requests: {
       cpu: '10m',
-      memory: '128Mi',
+      memory: '1Gi',
     },
   },
   podMonitor: true,
@@ -30,15 +30,6 @@ function(params={})
       spec+: {
         template+: {
           spec+: {
-            containers: [
-              if c.name == 'parca-agent' then c {
-                // TODO: Make it easy to pass extra args upstream.
-                args+: [
-                  '--bpf-verbose-logging',
-                ],
-              } else c
-              for c in super.containers
-            ],
             priorityClassName: 'system-node-critical',
           },
         },


### PR DESCRIPTION
> **brancz:** We should also increase the limits on the parca agents looks like they get oomkilled a bit too frequently.

https://discord.com/channels/877547706334199818/897027941039505458/1160939748290985985

> **maxbrunet:** `libbpf: prog 'walk_user_stacktrace_impl': BPF program load failed: Argument list too long\n`
> **brancz:** aaaaaahhhhh
> **brancz:** I remember
> **brancz:** we need to remove the verbose bpf logging flag
> **brancz:** it doesn't work on a 5.4 kernel

https://discord.com/channels/877547706334199818/897027941039505458/1160996220936929280

```diff
$ kubectl get node --output=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.kernelVersion}{"\n"}{end}'
scw-parca-demo-pool-gp1-xs-162ea11cdeb6489192d  5.4.0-148-generic
scw-parca-demo-pool-gp1-xs-3ff529871cbc42b28e4  5.4.0-148-generic
```

cc @brancz 