### PR TITLE
fix(parca): bump Parca's priority to cluster critical

### DIFF
--- a/parca-devel/lib/parca.libsonnet
+++ b/parca-devel/lib/parca.libsonnet
@@ -213,6 +213,7 @@ function(params)
               } else c
               for c in super.containers
             ],
+            priorityClassName: 'system-cluster-critical',
           },
         },
       },

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -35,6 +35,11 @@ function(params)
           // for running 2 Parca instances.
           type: 'Recreate',
         },
+        template+: {
+          spec+: {
+            priorityClassName: 'system-cluster-critical',
+          },
+        },
       },
     },
 


### PR DESCRIPTION
> **brancz:** @maxbrunet any idea what changed in the demo cluster? All of the sudden the Parca servers can't always be scheduled anymore with not enough resources being available.

https://discord.com/channels/877547706334199818/897027941039505458/1160939613704179812

Parca will be able to evict other components in order to schedule itself, hopefully other components are small enough to find room on another node.