### PR TITLE
Add thanos sidecar to parca-analytics

### DIFF
--- a/monitoring/environments/civo-demo/main.jsonnet
+++ b/monitoring/environments/civo-demo/main.jsonnet
@@ -129,6 +129,12 @@ local prometheuses = [
         query+: {
           lookbackDelta: '15m',  // Analytics are only sent once every 10m
         },
+        thanos: {
+          objectStorageConfig: {
+            name: 'parca-analytics-objectstorage',
+            key: 'thanos.yaml',
+          },
+        },
       },
     },
 


### PR DESCRIPTION
This will read the secret with the object storage config and then start sending Prometheus blocks to object storage.