### PR TITLE
fix(grafana): downgrade to v9

### DIFF
--- a/grafana/lib/grafana.libsonnet
+++ b/grafana/lib/grafana.libsonnet
@@ -8,7 +8,7 @@ local defaults = {
   ],
   namespace: 'grafana',
   // renovate: datasource=docker depName=docker.io/grafana/grafana
-  version: '10.1.5',
+  version: '9.5.13',
   replicas: 1,
   commonLabels+: {
     'app.kubernetes.io/component': 'observability',


### PR DESCRIPTION
The Parca datasource and panel do not support Grafana 10 yet, and Grafana 9 is still supported.