### PR TITLE
Fix object storage name and add PVC to Thanos store

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -159,6 +159,19 @@ local prometheusOperator = m.prometheusOperator();
 
 local kubeThanos = m.kubeThanos({
   namespace: 'parca-analytics',
+  objectStorageConfig: {
+    key: 'thanos.yaml',
+    name: 'parca-analytics-objectstorage',
+  },
+  volumeClaimTemplate: {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: { requests: { storage: '10Gi' } },
+      storageClassName: 'scw-bssd-retain',
+    },
+  },
 });
 
 {


### PR DESCRIPTION
```diff
<               name: thanos-objectstorage
---
>               name: parca-analytics-objectstorage
255a256,275
>   volumeClaimTemplates:
>   - apiVersion: v1
>     kind: PersistentVolumeClaim
>     metadata:
>       creationTimestamp: null
>       labels:
>         app.kubernetes.io/component: object-store-gateway
>         app.kubernetes.io/instance: thanos-store
>         app.kubernetes.io/name: thanos-store
>       name: data
>     spec:
>       accessModes:
>       - ReadWriteOnce
>       resources:
>         requests:
>           storage: 10Gi
>       storageClassName: scw-bssd-retain
>       volumeMode: Filesystem
>     status:
>       phase: Pending

```