### PR TITLE
Add network policies to kube-thanos

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -1,5 +1,22 @@
 local m = import 'main.libsonnet';
 
+local kubeThanos = m.kubeThanos({
+  namespace: 'parca-analytics',
+  objectStorageConfig: {
+    key: 'thanos.yaml',
+    name: 'parca-analytics-objectstorage',
+  },
+  volumeClaimTemplate: {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: { requests: { storage: '10Gi' } },
+      storageClassName: 'scw-bssd-retain',
+    },
+  },
+});
+
 local prometheuses = [
   m.prometheus({
     prometheus+:: {

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -166,6 +166,17 @@ local prometheuses = [
       },
     },
 
+    networkPolicy+: {
+      spec+: {
+        ingress+: [{
+          from: [{
+            namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
+            podSelector: { matchLabels: { 'app.kubernetes.io/name': 'thanos-query' } },
+          }],
+        }],
+      },
+    },
+
     // We do not monitor k8s metrics with this instance.
     clusterRole:: {},
     clusterRoleBinding:: {},

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -185,23 +185,6 @@ local prometheuses = [
 
 local prometheusOperator = m.prometheusOperator();
 
-local kubeThanos = m.kubeThanos({
-  namespace: 'parca-analytics',
-  objectStorageConfig: {
-    key: 'thanos.yaml',
-    name: 'parca-analytics-objectstorage',
-  },
-  volumeClaimTemplate: {
-    apiVersion: 'v1',
-    kind: 'PersistentVolumeClaim',
-    spec: {
-      accessModes: ['ReadWriteOnce'],
-      resources: { requests: { storage: '10Gi' } },
-      storageClassName: 'scw-bssd-retain',
-    },
-  },
-});
-
 {
   apiVersion: 'v1',
   kind: 'List',

--- a/monitoring/lib/kube-thanos.libsonnet
+++ b/monitoring/lib/kube-thanos.libsonnet
@@ -22,12 +22,79 @@ function(params={}) {
     replicas: 1,
     serviceMonitor: true,
   }),
-  store: store,
+  store: store + {
+    networkPolicy: {
+      kind: 'NetworkPolicy',
+      apiVersion: 'networking.k8s.io/v1',
+      metadata: {
+        name: 'thanos-store',
+        namespace: cfg.namespace,
+      },
+      spec: {
+        podSelector: {
+          matchLabels: {
+            'app.kubernetes.io/name': 'thanos-store',
+          },
+        },
+        egress: [{}], // Allow all outside egress to connect to object storage
+        ingress: [{
+          from: [{
+            namespaceSelector: {
+              matchLabels: {
+                'kubernetes.io/metadata.name': cfg.namespace,
+              },
+            },
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'thanos-query',
+              },
+            },
+          }],
+        }],
+        policyTypes: ['Egress'],
+      },
+    },
+  },
 
   query: t.query(cfg {
     replicas: 1,
     replicaLabels: ['prometheus_replica', 'rule_replica'],
     serviceMonitor: true,
     stores: [store.storeEndpoint, 'dnssrv+_grpc._tcp.prometheus-parca-analytics-thanos-sidecar.%s.svc.cluster.local' % cfg.namespace],
-  }),
+  }) + {
+    networkPolicy: {
+      kind: 'NetworkPolicy',
+      apiVersion: 'networking.k8s.io/v1',
+      metadata: {
+        name: 'thanos-query',
+        namespace: 'parca-analytics',
+      },
+      spec: {
+        podSelector: {
+          matchLabels: {
+            'app.kubernetes.io/name': 'thanos-query',
+          },
+        },
+        egress: [{
+          to: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'parca-analytics',
+                },
+              },
+            },
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'kube-system',
+                },
+              },
+            },
+          ],
+        }],
+      },
+    },
+
+  }
 }

--- a/monitoring/lib/kube-thanos.libsonnet
+++ b/monitoring/lib/kube-thanos.libsonnet
@@ -22,7 +22,7 @@ function(params={}) {
     replicas: 1,
     serviceMonitor: true,
   }),
-  store: store + {
+  store: store {
     networkPolicy: {
       kind: 'NetworkPolicy',
       apiVersion: 'networking.k8s.io/v1',
@@ -36,7 +36,7 @@ function(params={}) {
             'app.kubernetes.io/name': 'thanos-store',
           },
         },
-        egress: [{}], // Allow all outside egress to connect to object storage
+        egress: [{}],  // Allow all outside egress to connect to object storage
         ingress: [{
           from: [{
             namespaceSelector: {
@@ -96,5 +96,5 @@ function(params={}) {
       },
     },
 
-  }
+  },
 }


### PR DESCRIPTION
```diff
===== networking.k8s.io/NetworkPolicy parca-analytics/prometheus-parca-analytics ======
53a54,60
>   - from:
>     - namespaceSelector:
>         matchLabels:
>           kubernetes.io/metadata.name: parca-analytics
>       podSelector:
>         matchLabels:
>           app.kubernetes.io/name: thanos-query

===== tanka.dev/Environment /environments/scaleway-parca-demo ======

===== networking.k8s.io/NetworkPolicy parca-analytics/thanos-query ======
0a1,19
> apiVersion: networking.k8s.io/v1
> kind: NetworkPolicy
> metadata:
>   annotations:
>     argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:networking.k8s.io/NetworkPolicy:parca-analytics/thanos-query
>   name: thanos-query
>   namespace: parca-analytics
> spec:
>   egress:
>   - to:
>     - namespaceSelector:
>         matchLabels:
>           kubernetes.io/metadata.name: parca-analytics
>     - namespaceSelector:
>         matchLabels:
>           kubernetes.io/metadata.name: kube-system
>   podSelector:
>     matchLabels:
>       app.kubernetes.io/name: thanos-query

===== networking.k8s.io/NetworkPolicy parca-analytics/thanos-store ======
0a1,23
> apiVersion: networking.k8s.io/v1
> kind: NetworkPolicy
> metadata:
>   annotations:
>     argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:networking.k8s.io/NetworkPolicy:parca-analytics/thanos-store
>   name: thanos-store
>   namespace: parca-analytics
> spec:
>   egress:
>   - {}
>   ingress:
>   - from:
>     - namespaceSelector:
>         matchLabels:
>           kubernetes.io/metadata.name: parca-analytics
>       podSelector:
>         matchLabels:
>           app.kubernetes.io/name: thanos-query
>   podSelector:
>     matchLabels:
>       app.kubernetes.io/name: thanos-store
>   policyTypes:
>   - Egress
```