### PR TITLE
Direct analytics.parca.dev to thanos-query

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -15,7 +15,29 @@ local kubeThanos = m.kubeThanos({
       storageClassName: 'scw-bssd-retain',
     },
   },
-});
+}) + {
+  query+: {
+    networkPolicy+: {
+      spec+: {
+        ingress: [
+          {
+            from: [{
+              namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'ingress-nginx' } },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/component': 'controller',
+                  'app.kubernetes.io/instance': 'ingress-nginx',
+                  'app.kubernetes.io/name': 'ingress-nginx',
+                },
+              },
+            }],
+            ports: [{ port: 'http', protocol: 'TCP' }],
+          },
+        ],
+      },
+    },
+  },
+};
 
 local prometheuses = [
   m.prometheus({
@@ -81,9 +103,9 @@ local prometheuses = [
               paths: [{
                 backend: {
                   service: {
-                    name: p.service.metadata.name,
+                    name: kubeThanos.query.service.metadata.name,
                     port: {
-                      name: p.service.spec.ports[0].name,
+                      name: kubeThanos.query.service.spec.ports[1].name,
                     },
                   },
                 },


### PR DESCRIPTION
Instead of connecting to Prometheus with only 1d retention.

```diff
===== networking.k8s.io/Ingress parca-analytics/parca-analytics ======
58c58
<             name: prometheus-parca-analytics
---
>             name: thanos-query
60c60
<               name: web
---
>               name: http

===== networking.k8s.io/NetworkPolicy parca-analytics/thanos-query ======
32a33,45
>   ingress:
>   - from:
>     - namespaceSelector:
>         matchLabels:
>           kubernetes.io/metadata.name: ingress-nginx
>       podSelector:
>         matchLabels:
>           app.kubernetes.io/component: controller
>           app.kubernetes.io/instance: ingress-nginx
>           app.kubernetes.io/name: ingress-nginx
>     ports:
>     - port: http
>       protocol: TCP

===== tanka.dev/Environment /environments/scaleway-parca-demo ======
```