### PR TITLE
fix(monitoring): set thanos resources + misc

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -20,10 +20,11 @@ config:
   secret_key: XXX
 ```
 
-Use the following command to create it in the cluster.
+Use the following command to patch it into the cluster.
 
 ```bash
-kubectl -n parca-analytics create secret generic parca-analytics-objectstorage --from-file=thanos.yaml=/tmp/thanos.yaml
+jq -Rs '{"data": {"thanos.yaml": .|@base64 }}' /tmp/thanos.yaml \
+  | kubectl patch --namespace=parca-analytics secret parca-analytics-objectstorage --patch-file=/dev/stdin
 ```
 
 This will unblock the parca-analytics Prometheus Pod and it will start uploading data to the object storage.

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -73,9 +73,21 @@ local prometheuses = [
         hosts: ['analytics.parca.dev'],
       },
       thanos: {
+        image: 'quay.io/thanos/thanos:%s' % self.version,
+        // renovate: datasource=docker depName=quay.io/thanos/thanos
+        version: 'v0.32.5',
         objectStorageConfig: {
           key: 'thanos.yaml',
           name: 'parca-analytics-objectstorage',
+        },
+        resources+: {
+          limits+: {
+            memory: '64Mi',
+          },
+          requests+: {
+            cpu: '50m',
+            memory: '64Mi',
+          },
         },
       },
     },
@@ -87,7 +99,8 @@ local prometheuses = [
       kind: 'Ingress',
       metadata: {
         name: 'parca-analytics',
-        namespace: 'parca-analytics',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
         annotations: {
           'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
           'nginx.ingress.kubernetes.io/auth-url': 'http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth',
@@ -130,8 +143,9 @@ local prometheuses = [
       apiVersion: 'networking.k8s.io/v1',
       kind: 'Ingress',
       metadata: {
-        name: 'parca-analytics-remote-write',
-        namespace: 'parca-analytics',
+        name: p._config.name + '-remote-write',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
         annotations: {
           'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
         },
@@ -185,6 +199,16 @@ local prometheuses = [
             },
           },
         },
+      },
+    },
+
+    objectStorageSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: p._config.name + '-objectstorage',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
       },
     },
 

--- a/monitoring/jsonnetfile.json
+++ b/monitoring/jsonnetfile.json
@@ -17,7 +17,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "security-context"
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/monitoring/jsonnetfile.lock.json
+++ b/monitoring/jsonnetfile.lock.json
@@ -171,7 +171,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "d94f051cdb980f11259d7481422f0d7c88090f2e",
+      "version": "48639958ccd4fa81fbb261ce4f9e790d69c71e2e",
       "sum": "22UgIfAACAxg2HRyAXFIN8Qi+p8rEcbWoM5XsXu9Mdo="
     },
     {


### PR DESCRIPTION
* Set resources for Thanos query/sidecar/store
* Ensure consistent labeling
* Track kube-thanos `main` branch (upstream PR has been merged)
* Track object storage secret, this is nice to manage its metadata and have a complete view of the deployment from Argo CD
* Ensure sidecar runs the same version as the other components
* Fix Renovate comment

```diff
===== apps/Deployment parca-analytics/thanos-query ======
diff --git a/tmp/argocd-diff1981062498/thanos-query-live.yaml b/tmp/argocd-diff1981062498/thanos-query
index 7559388..8652e38 100644
--- a/tmp/argocd-diff1981062498/thanos-query-live.yaml
+++ b/tmp/argocd-diff1981062498/thanos-query
@@ -218,7 +218,12 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        resources: {}
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

===== apps/StatefulSet parca-analytics/thanos-store ======
diff --git a/tmp/argocd-diff1282949900/thanos-store-live.yaml b/tmp/argocd-diff1282949900/thanos-store
index 79c6541..dcf738b 100644
--- a/tmp/argocd-diff1282949900/thanos-store-live.yaml
+++ b/tmp/argocd-diff1282949900/thanos-store
@@ -220,7 +220,12 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        resources: {}
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

===== monitoring.coreos.com/Prometheus parca-analytics/parca-analytics ======
diff --git a/tmp/argocd-diff225167637/parca-analytics-live.yaml b/tmp/argocd-diff225167637/parca-analytics
index f91fefb..30579c2 100644
--- a/tmp/argocd-diff225167637/parca-analytics-live.yaml
+++ b/tmp/argocd-diff225167637/parca-analytics
@@ -189,10 +189,17 @@ spec:
         storageClassName: scw-bssd-retain
   thanos:
     blockSize: 2h
-    image: quay.io/thanos/thanos:v0.32.4
+    image: quay.io/thanos/thanos:v0.32.5
     objectStorageConfig:
       key: thanos.yaml
       name: parca-analytics-objectstorage
+    resources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    version: v0.32.5
   version: 2.47.2
 status:
   availableReplicas: 1

===== networking.k8s.io/Ingress parca-analytics/parca-analytics ======
diff --git a/tmp/argocd-diff680284146/parca-analytics-live.yaml b/tmp/argocd-diff680284146/parca-analytics
index fe96b01..ac73788 100644
--- a/tmp/argocd-diff680284146/parca-analytics-live.yaml
+++ b/tmp/argocd-diff680284146/parca-analytics
@@ -7,6 +7,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: https://oauth2.parca.dev/oauth2/start
     nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth
   generation: 8
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: parca-analytics
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.47.2
   managedFields:
   - apiVersion: networking.k8s.io/v1
     fieldsType: FieldsV1

===== networking.k8s.io/Ingress parca-analytics/parca-analytics-remote-write ======
diff --git a/tmp/argocd-diff1444959660/parca-analytics-remote-write-live.yaml b/tmp/argocd-diff1444959660/parca-analytics-remote-write
index 71a0397..61b01bf 100644
--- a/tmp/argocd-diff1444959660/parca-analytics-remote-write-live.yaml
+++ b/tmp/argocd-diff1444959660/parca-analytics-remote-write
@@ -5,6 +5,12 @@ metadata:
     argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:networking.k8s.io/Ingress:parca-analytics/parca-analytics-remote-write
     cert-manager.io/cluster-issuer: letsencrypt-prod
   generation: 1
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: parca-analytics
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.47.2
   managedFields:
   - apiVersion: networking.k8s.io/v1
     fieldsType: FieldsV1

===== networking.k8s.io/NetworkPolicy parca-analytics/thanos-query ======
diff --git a/tmp/argocd-diff421750321/thanos-query-live.yaml b/tmp/argocd-diff421750321/thanos-query
index 2ba9cdb..62a377f 100644
--- a/tmp/argocd-diff421750321/thanos-query-live.yaml
+++ b/tmp/argocd-diff421750321/thanos-query
@@ -4,6 +4,11 @@ metadata:
   annotations:
     argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:networking.k8s.io/NetworkPolicy:parca-analytics/thanos-query
   generation: 4
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.32.5
   managedFields:
   - apiVersion: networking.k8s.io/v1
     fieldsType: FieldsV1
@@ -46,6 +51,8 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: thanos-query
       app.kubernetes.io/name: thanos-query
   policyTypes:
   - Ingress

===== networking.k8s.io/NetworkPolicy parca-analytics/thanos-store ======
diff --git a/tmp/argocd-diff3874732768/thanos-store-live.yaml b/tmp/argocd-diff3874732768/thanos-store
index d050178..19b9897 100644
--- a/tmp/argocd-diff3874732768/thanos-store-live.yaml
+++ b/tmp/argocd-diff3874732768/thanos-store
@@ -4,6 +4,11 @@ metadata:
   annotations:
     argocd.argoproj.io/tracking-id: scaleway-parca-demo-monitoring:networking.k8s.io/NetworkPolicy:parca-analytics/thanos-store
   generation: 1
+  labels:
+    app.kubernetes.io/component: object-store-gateway
+    app.kubernetes.io/instance: thanos-store
+    app.kubernetes.io/name: thanos-store
+    app.kubernetes.io/version: v0.32.5
   managedFields:
   - apiVersion: networking.k8s.io/v1
     fieldsType: FieldsV1
@@ -36,6 +41,8 @@ spec:
           app.kubernetes.io/name: thanos-query
   podSelector:
     matchLabels:
+      app.kubernetes.io/component: object-store-gateway
+      app.kubernetes.io/instance: thanos-store
       app.kubernetes.io/name: thanos-store
   policyTypes:
   - Egress
```