### PR TITLE
fix(parca-devel): fix block/mutex profile flags

### DIFF
--- a/parca-devel/lib/parca-agent.libsonnet
+++ b/parca-devel/lib/parca-agent.libsonnet
@@ -32,7 +32,7 @@ function(params={})
         template+: {
           spec+: {
             containers: [
-              if c.name == 'parca' then c {
+              if c.name == 'parca-agent' then c {
                 // TODO: Make it easy to pass extra args upstream.
                 args+: [
                   // One percent of events are profiled.


### PR DESCRIPTION
```diff
===== apps/DaemonSet parca-devel/parca-agent-devel ======
diff --git a/tmp/argocd-diff4088286657/parca-agent-devel-live.yaml b/tmp/argocd-diff4088286657/parca-agent-devel
index 5958d90..b557aa7 100644
--- a/tmp/argocd-diff4088286657/parca-agent-devel-live.yaml
+++ b/tmp/argocd-diff4088286657/parca-agent-devel
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    argocd.argoproj.io/tracking-id: scaleway-parca-demo-parca-devel:apps/DaemonSet:parca-devel/parca-agent-devel
+    argocd.argoproj.io/tracking-id: argocd_scaleway-parca-demo-parca-devel:apps/DaemonSet:parca-devel/parca-agent-devel
     deprecated.daemonset.template.generation: "388"
   generation: 388
   labels:
@@ -239,6 +239,8 @@ spec:
         - --debuginfo-temp-dir=/tmp
         - --debuginfo-upload-cache-duration=5m
         - --debuginfo-upload-timeout-duration=2m
+        - --mutex-profile-fraction=100
+        - --block-profile-rate=100
         env:
         - name: NODE_NAME
           valueFrom:

===== tanka.dev/Environment /environments/scaleway-parca-demo ======
```