### PR TITLE
fix(ingress-nginx): enable network policy for webhook

### DIFF
--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -43,6 +43,8 @@ ingress-nginx:
            drop:
            - ALL
       patch:
+        networkPolicy:
+          enabled: true
         securityContext:
           seccompProfile:
             type: RuntimeDefault


### PR DESCRIPTION
A flag was added and it is disable by default (kubernetes/ingress-nginx@bfc2300c3d0cd35aa16324b35d865b7a0a6f4bbb)