### PR TITLE
Increase nginx limits to 2Gi 

### DIFF
--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -14,7 +14,7 @@ ingress-nginx:
       enabled: true
     resources:
       limits:
-        memory: 1Gi
+        memory: 2Gi
       requests:
         cpu: 100m
         memory: 256Mi


### PR DESCRIPTION
It crash loops otherwise. Not sure why it needs that much memory. 
