### PR TITLE
Bump prometheus memory limit to 1Gi

### DIFF
--- a/monitoring/lib/prometheus.libsonnet
+++ b/monitoring/lib/prometheus.libsonnet
@@ -19,7 +19,7 @@ local defaults = {
     enableFeatures: ['native-histograms'],
     resources+: {
       limits+: {
-        memory: '512Mi',
+        memory: '1Gi',
       },
       requests+: {
         cpu: '100m',


### PR DESCRIPTION
Other than this I don't know why we have 700 restarts.