### PR TITLE
Scale analytics stack to 0 replicas

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -16,7 +16,11 @@ local kubeThanos = m.kubeThanos({
     },
   },
 }) + {
+  // Analytics stack temporarily scaled to 0 while we evaluate moving it off this
+  // cluster. PVCs, services and object storage are retained; only pods stop.
+  store+: { statefulSet+: { spec+: { replicas: 0 } } },
   query+: {
+    deployment+: { spec+: { replicas: 0 } },
     networkPolicy+: {
       spec+: {
         ingress: [
@@ -184,6 +188,8 @@ local prometheuses = [
 
     prometheus+: {
       spec+: {
+        // Analytics stack temporarily scaled to 0 (see kubeThanos above).
+        replicas: 0,
         enableRemoteWriteReceiver: true,
         query+: {
           lookbackDelta: '15m',  // Analytics are only sent once every 10m

--- a/oauth2-proxy/values/scaleway-parca-demo.yaml
+++ b/oauth2-proxy/values/scaleway-parca-demo.yaml
@@ -1,4 +1,7 @@
 oauth2-proxy:
+  # Scaled to 0: only fronts analytics.parca.dev, which is paused while the
+  # analytics stack is evaluated for moving off this cluster.
+  replicaCount: 0
   ingress:
     hosts:
     - oauth2.parca.dev


### PR DESCRIPTION
Analytics ingestion has effectively been down anyway since it shares the single, wedged ingress-nginx controller, so this scales the whole analytics stack (parca-analytics Prometheus, thanos-query, thanos-store, and the oauth2-proxy fronting analytics.parca.dev) to zero to confirm the demo runs healthily without it while we evaluate moving analytics onto its own cluster.

Nothing is deleted, only the pods stop, so restoring the replica counts reverts it.