### PR TITLE
Run ingress-nginx with two replicas and looser probes

### DIFF
--- a/ingress-nginx/values/scaleway-parca-demo.yaml
+++ b/ingress-nginx/values/scaleway-parca-demo.yaml
@@ -1,5 +1,25 @@
 ingress-nginx:
   controller:
+    # Run two controllers so a single wedged/flapping pod can't take ingress
+    # down (a single replica pegged its CPU and failed its 1s healthz probe,
+    # flapping NotReady and dropping the only LB backend).
+    replicaCount: 2
+    minAvailable: 1
+    # The default 1s probe timeout flaps NotReady under load; give it headroom.
+    livenessProbe:
+      timeoutSeconds: 5
+    readinessProbe:
+      timeoutSeconds: 5
+    # Keep the two replicas on different nodes (soft, so rollouts never block).
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: ingress-nginx
+            app.kubernetes.io/instance: ingress-nginx
+            app.kubernetes.io/component: controller
     service:
       annotations:
         service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"


### PR DESCRIPTION
A single ingress-nginx controller wedged its CPU at ~1.4 cores and started missing the chart's default 1s healthz probe, flapping NotReady and dropping the only LoadBalancer backend. That intermittently broke ingress, including the analytics remote-write path. Deleting the pod cleared it for now (CPU dropped back to ~40m), but a single replica leaves no headroom for it to happen again.

This runs two controllers behind a PodDisruptionBudget, spreads them across nodes, and bumps the liveness/readiness probe timeout to 5s so one slow or wedged pod can no longer take ingress down. It's scoped to the overlay so it doesn't touch the base values.