### PR TITLE
fix(pyrra): satisfy restricted Pod Security Standard

### DIFF
--- a/pyrra/lib/main.libsonnet
+++ b/pyrra/lib/main.libsonnet
@@ -41,17 +41,28 @@ local ingressNginx = {
       limits: { memory: '128Mi' },
     },
 
+    // The monitoring namespace enforces the restricted Pod Security Standard.
+    // The image already runs as a non-root user (USER 65533).
+    local podSecurityContext = {
+      runAsNonRoot: true,
+      seccompProfile: { type: 'RuntimeDefault' },
+    },
+    local hardened(container) = container {
+      resources: resources,
+      securityContext+: { capabilities: { drop: ['ALL'] } },
+    },
+
     apiDeployment+: {
       spec+: { template+: { spec+: {
-        securityContext+: { seccompProfile: { type: 'RuntimeDefault' } },
-        containers: [c { resources: resources } for c in super.containers],
+        securityContext+: podSecurityContext,
+        containers: [hardened(c) for c in super.containers],
       } } },
     },
 
     kubernetesDeployment+: {
       spec+: { template+: { spec+: {
-        securityContext+: { seccompProfile: { type: 'RuntimeDefault' } },
-        containers: [c { resources: resources } for c in super.containers],
+        securityContext+: podSecurityContext,
+        containers: [hardened(c) for c in super.containers],
       } } },
     },
 


### PR DESCRIPTION
The Pyrra pods never got created after the first sync: the `monitoring` namespace enforces the restricted Pod Security Standard, which rejected them for missing `runAsNonRoot` and `capabilities.drop: ["ALL"]`. This sets both (the image already runs as non-root), matching how Prometheus is hardened in the same namespace.