### PR TITLE
feat(traefik): deploy alongside ingress-nginx for migration

### DIFF
--- a/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
+++ b/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
@@ -56,6 +56,10 @@ local applications =
       name: 'oauth2-proxy',
       namespace: 'oauth2-proxy',
     }),
+    u.newHelmApp(common {
+      name: 'traefik',
+      namespace: 'traefik',
+    }),
     u.newJsonnetApp(common {
       name: 'parca',
       namespace: 'parca',

--- a/cert-manager/templates/ciliumclusterwidenetworkpolicy.yaml
+++ b/cert-manager/templates/ciliumclusterwidenetworkpolicy.yaml
@@ -13,6 +13,9 @@ spec:
         k8s:app.kubernetes.io/component: controller
         k8s:app.kubernetes.io/instance: ingress-nginx
         k8s:io.kubernetes.pod.namespace: ingress-nginx
+    - matchLabels:
+        k8s:app.kubernetes.io/name: traefik
+        k8s:io.kubernetes.pod.namespace: traefik
     toPorts:
     - ports:
       - port: http

--- a/cluster-config/base/namespaces.yaml
+++ b/cluster-config/base/namespaces.yaml
@@ -52,6 +52,16 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: traefik
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.27
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: oauth2-proxy
   labels:
     pod-security.kubernetes.io/audit: restricted

--- a/grafana/lib/grafana.libsonnet
+++ b/grafana/lib/grafana.libsonnet
@@ -132,6 +132,18 @@ function(params)
                 },
               },
             },
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'traefik',
+                },
+              },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'traefik',
+                },
+              },
+            },
           ],
           ports: [{
             port: 'http',

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -30,6 +30,9 @@ local kubeThanos = m.kubeThanos({
                   'app.kubernetes.io/name': 'ingress-nginx',
                 },
               },
+            }, {
+              namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'traefik' } },
+              podSelector: { matchLabels: { 'app.kubernetes.io/name': 'traefik' } },
             }],
             ports: [{ port: 'http', protocol: 'TCP' }],
           },

--- a/monitoring/lib/prometheus.libsonnet
+++ b/monitoring/lib/prometheus.libsonnet
@@ -74,6 +74,18 @@ function(params={}) (
                   },
                 },
               },
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    'kubernetes.io/metadata.name': 'traefik',
+                  },
+                },
+                podSelector: {
+                  matchLabels: {
+                    'app.kubernetes.io/name': 'traefik',
+                  },
+                },
+              },
             ],
             ports: [{
               port: 'web',

--- a/oauth2-proxy/templates/networkpolicy.yaml
+++ b/oauth2-proxy/templates/networkpolicy.yaml
@@ -21,6 +21,12 @@ spec:
           app.kubernetes.io/name: ingress-nginx
           app.kubernetes.io/component: controller
           app.kubernetes.io/instance: ingress-nginx
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: traefik
     ports:
     - port: http
   podSelector:

--- a/parca-devel/lib/parca.libsonnet
+++ b/parca-devel/lib/parca.libsonnet
@@ -295,6 +295,18 @@ function(params)
               },
             },
             {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'traefik',
+                },
+              },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'traefik',
+                },
+              },
+            },
+            {
               podSelector: {
                 matchLabels: {
                   'app.kubernetes.io/name': 'parca-agent',

--- a/parca/lib/parca.libsonnet
+++ b/parca/lib/parca.libsonnet
@@ -124,6 +124,18 @@ function(params)
               },
             },
             {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'traefik',
+                },
+              },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'traefik',
+                },
+              },
+            },
+            {
               podSelector: {
                 matchLabels: {
                   'app.kubernetes.io/name': 'parca-agent',

--- a/traefik/Chart.lock
+++ b/traefik/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: traefik
+  repository: https://traefik.github.io/charts
+  version: 41.0.0
+digest: sha256:d80982aeef7a3935c30017f406098005f6cfc294f275a3c9c6a9ba5ced95b2ba
+generated: "2026-06-24T11:43:18.10069385+02:00"

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: traefik
+version: 0.0.0
+dependencies:
+- name: traefik
+  version: 41.0.0
+  repository: https://traefik.github.io/charts

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,0 +1,6 @@
+# traefik
+
+See https://artifacthub.io/packages/helm/traefik/traefik
+
+Deployed in `kubernetesIngressNGINX` provider mode so Traefik serves the existing
+`ingressClassName: nginx` Ingresses during the migration away from ingress-nginx.

--- a/traefik/templates/networkpolicy.yaml
+++ b/traefik/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: Helm
+spec:
+  # Cilium runs a cluster-wide default-deny, so Traefik must ship its own policy.
+  # The traefik namespace only runs Traefik, so select every pod in it.
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - {}
+  ingress:
+  # Public entrypoints, reached through the Scaleway LoadBalancer.
+  - ports:
+    - port: web
+    - port: websecure
+  # Prometheus metrics scraped from the monitoring namespace.
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+    ports:
+    - port: metrics

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1,0 +1,52 @@
+traefik:
+  # Migration mode: serve the existing `ingressClassName: nginx` Ingresses and translate
+  # the nginx.ingress.kubernetes.io/* annotations natively, running in parallel with
+  # ingress-nginx until the DNS cutover.
+  # https://doc.traefik.io/traefik/migrate/nginx-to-traefik/
+  providers:
+    kubernetesIngressNGINX:
+      enabled: true
+      # Defaults are correct for us: controllerClass "k8s.io/ingress-nginx",
+      # ingressClass "nginx", watching all namespaces.
+    kubernetesIngress:
+      publishedService:
+        # Do not write the Ingress .status.loadBalancer address while ingress-nginx is
+        # still the source of truth, to avoid the two controllers flapping the status.
+        enabled: false
+    kubernetesCRD:
+      # Needed for the native Middleware/IngressRoute CRDs we switch to in the final phase.
+      enabled: true
+
+  # The Traefik-native IngressClass exists for the end state but must not become the default,
+  # so it never hijacks Ingresses that omit a class.
+  ingressClass:
+    enabled: true
+    isDefaultClass: false
+
+  service:
+    spec:
+      type: LoadBalancer
+      # Preserve client source IPs (matches ingress-nginx); the Scaleway LB also forwards
+      # them via PROXY protocol.
+      externalTrafficPolicy: Local
+
+  ports:
+    web:
+      proxyProtocol:
+        # The Scaleway LB prepends PROXY protocol v2 (mirrors ingress-nginx
+        # use-proxy-protocol). TODO(hardening): restrict to the Scaleway LB source range.
+        insecure: true
+      forwardedHeaders:
+        insecure: true
+    websecure:
+      proxyProtocol:
+        insecure: true
+      forwardedHeaders:
+        insecure: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi

--- a/traefik/values/scaleway-parca-demo.yaml
+++ b/traefik/values/scaleway-parca-demo.yaml
@@ -1,0 +1,6 @@
+traefik:
+  service:
+    annotations:
+      service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
+      service.beta.kubernetes.io/scw-loadbalancer-use-hostname: "true"
+      service.beta.kubernetes.io/scw-loadbalancer-zone: "nl-ams-2"


### PR DESCRIPTION
The ingress-nginx project retires in March 2026, so we need to move demo.parca.dev to Traefik. Traefik v3.7's `kubernetesIngressNGINX` provider serves our existing `nginx`-class Ingresses unchanged and translates the annotations natively, so it runs in parallel on its own Scaleway LoadBalancer until we flip DNS. These two phases have no production impact — DNS still points at nginx — and are reversible.

This is Phases 1–2 of `docs/traefik-migration.md`: deploy Traefik in compat mode, and allow it through the backends' Cilium NetworkPolicies. After merge it needs a manual `argocd-applications` sync, then per-host validation on Traefik's new LB before the DNS cutover (Phase 3) and the native-Traefik conversion plus nginx removal (Phase 4).
