### PR TITLE
fix(pyrra): unblock pyrra.parca.dev on Traefik (network policy + public)

### DIFF
--- a/pyrra/lib/main.libsonnet
+++ b/pyrra/lib/main.libsonnet
@@ -14,6 +14,13 @@ local ingressNginx = {
   },
 };
 
+// Traefik runs alongside ingress-nginx during the migration and serves the
+// same Ingresses, so it has to be an allowed source too.
+local traefik = {
+  namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'traefik' } },
+  podSelector: { matchLabels: { 'app.kubernetes.io/name': 'traefik' } },
+};
+
 {
   pyrra(params):: (
     pyrra {
@@ -111,8 +118,8 @@ local ingressNginx = {
         policyTypes: ['Egress', 'Ingress'],
         egress: [{}],
         ingress: [
-          // UI traffic via ingress-nginx and Prometheus scraping the API metrics.
-          { from: [ingressNginx, { podSelector: { matchLabels: prometheus } }], ports: [{ port: 9099 }] },
+          // UI traffic via the ingress controllers and Prometheus scraping the API metrics.
+          { from: [ingressNginx, traefik, { podSelector: { matchLabels: prometheus } }], ports: [{ port: 9099 }] },
         ],
       },
     },


### PR DESCRIPTION
Two small Pyrra changes to get `pyrra.parca.dev` working on the Traefik LB. The 504 was Cilium's default-deny dropping Traefik→`pyrra-api`, because Pyrra landed in the `monitoring` namespace after the migration's network-policy pass — so its policy now allows Traefik as a source (additive, nginx stays). And since Pyrra only exposes the cluster's SLO data, it no longer needs the oauth2-proxy gate, so the ingress is served publicly.
