### PR TITLE
feat(traefik): enable insecure dashboard/API for local debugging

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -17,6 +17,14 @@ traefik:
       # Needed for the native Middleware/IngressRoute CRDs we switch to in the final phase.
       enabled: true
 
+  # Dashboard/API only bind to the "traefik" entrypoint (port 8080), which the
+  # LoadBalancer Service never exposes (only web/websecure are published) — so
+  # `insecure: true` here is still only reachable via `kubectl port-forward`, never
+  # from the internet.
+  api:
+    dashboard: true
+    insecure: true
+
   # The Traefik-native IngressClass exists for the end state but must not become the default,
   # so it never hijacks Ingresses that omit a class.
   ingressClass:


### PR DESCRIPTION
- The Traefik dashboard/API router never binds to any entrypoint unless `api.insecure` is set — `api.dashboard: true` alone only flips a feature flag, it doesn't attach a router. Confirmed via `kubectl exec` into the pod: `curl localhost:8080/dashboard/` returned 404 even from inside.
- Enables `api.insecure: true`, which is safe here because the `traefik` entrypoint (port 8080) it binds to is never published by the `LoadBalancer` Service (only `web`/`websecure` are) — reachable only via `kubectl port-forward deploy/traefik 8080:8080`, never from the internet.
