### PR TITLE
feat(ingress-nginx): enable prometheus metrics

### DIFF
--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
         service.beta.kubernetes.io/scw-loadbalancer-zone: "nl-ams-2"
     config:
       use-proxy-protocol: "true"
+    # Temporary: lets us watch request volume drop off during the Traefik cutover.
+    metrics:
+      enabled: true
     networkPolicy:
       enabled: true
     resources:


### PR DESCRIPTION
We're mid-cutover to Traefik and analytics.parca.dev is still getting real traffic on the old controller as external parca-agent installations' DNS caches expire. This gives us a metrics endpoint to watch that decay over time instead of tailing access logs, so we know when it's safe to decommission ingress-nginx.