### PR TITLE
feat(traefik,ingress-nginx): add PodMonitors for in-cluster scraping

### DIFF
--- a/ingress-nginx/templates/podmonitor.yaml
+++ b/ingress-nginx/templates/podmonitor.yaml
@@ -1,0 +1,17 @@
+# Temporary: lets us watch request volume drop off during the Traefik cutover.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/component: controller

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -191,8 +191,8 @@ local prometheuses = [
         // This instance only ingests via remote-write and monitors its own Thanos
         // components. The default {} selectors match every PodMonitor/ServiceMonitor
         // cluster-wide, which would pull in unrelated apps (parca-agent, pyrra, ...).
-        podMonitorNamespaceSelector: { matchNames: [p._config.namespace] },
-        serviceMonitorNamespaceSelector: { matchNames: [p._config.namespace] },
+        podMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
+        serviceMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
         query+: {
           lookbackDelta: '15m',  // Analytics are only sent once every 10m
         },

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -188,6 +188,11 @@ local prometheuses = [
     prometheus+: {
       spec+: {
         enableRemoteWriteReceiver: true,
+        // This instance only ingests via remote-write and monitors its own Thanos
+        // components. The default {} selectors match every PodMonitor/ServiceMonitor
+        // cluster-wide, which would pull in unrelated apps (parca-agent, pyrra, ...).
+        podMonitorNamespaceSelector: { matchNames: [p._config.namespace] },
+        serviceMonitorNamespaceSelector: { matchNames: [p._config.namespace] },
         query+: {
           lookbackDelta: '15m',  // Analytics are only sent once every 10m
         },

--- a/traefik/templates/podmonitor.yaml
+++ b/traefik/templates/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik


### PR DESCRIPTION
Both controllers already run their own metrics endpoints (from #447 and #448), but nothing in-cluster was scraping them. The monitoring/parca Prometheus has empty pod/service monitor selectors, so it'll pick these up automatically once merged, no need for local port-forwards to watch the cutover anymore.

Also scopes the parca-analytics Prometheus to its own namespace: it had the same empty selectors and was already scraping unrelated apps (parca-agent, pyrra) alongside its own Thanos components, and would've picked up the new monitors too.