### PR TITLE
feat(monitoring): grant parca Prometheus RBAC in traefik,ingress-nginx

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -46,7 +46,10 @@ local prometheuses = [
   m.prometheus({
     prometheus+:: {
       name: 'parca',
-      namespaces: ['parca', 'parca-devel'],
+      // RBAC (Role/RoleBinding) to list/watch pods,services,endpoints is only
+      // generated for namespaces listed here, regardless of what the Prometheus
+      // CR's podMonitorNamespaceSelector/serviceMonitorNamespaceSelector match.
+      namespaces: ['parca', 'parca-devel', 'traefik', 'ingress-nginx'],
     },
   }) {
     prometheus+: {


### PR DESCRIPTION
After #449 merged, the new PodMonitors weren't showing up as targets. Turns out the Prometheus CR's match-all selectors don't actually grant scrape access: kube-prometheus only creates the Role/RoleBinding to list pods/services/endpoints for namespaces explicitly named in its own config, and traefik/ingress-nginx weren't in that list. Confirmed via 403s in the Prometheus logs.