### PR TITLE
feat(monitoring): grant parca Prometheus RBAC in its own namespaces

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -49,7 +49,7 @@ local prometheuses = [
       // RBAC (Role/RoleBinding) to list/watch pods,services,endpoints is only
       // generated for namespaces listed here, regardless of what the Prometheus
       // CR's podMonitorNamespaceSelector/serviceMonitorNamespaceSelector match.
-      namespaces: ['parca', 'parca-devel', 'traefik', 'ingress-nginx'],
+      namespaces: ['parca', 'parca-devel', 'traefik', 'ingress-nginx', 'monitoring', 'parca-analytics'],
     },
   }) {
     prometheus+: {


### PR DESCRIPTION
While confirming #450 fixed the traefik/ingress-nginx 403s, the remaining log spam turned out to be the same bug, just pre-existing: monitoring and parca-analytics were never in the RBAC namespace list either, so pyrra's and Thanos's ServiceMonitors have apparently never actually been scraped by this Prometheus.