### PR TITLE
fix(traefik): bump memory limit to 2Gi

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -57,4 +57,6 @@ traefik:
       cpu: 100m
       memory: 256Mi
     limits:
-      memory: 1Gi
+      # Matches ingress-nginx's limit for the same workload; the analytics
+      # remote-write volume alone was enough to OOMKill at 1Gi.
+      memory: 2Gi


### PR DESCRIPTION
It's OOMKilling and crash-looping right now under full production traffic, dropping every host it serves each time it restarts. ingress-nginx handled the same load at 2Gi, so matching that.