### PR TITLE
fix(traefik,monitoring): resolve CPU contention crash loop

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -196,6 +196,16 @@ local prometheuses = [
         // cluster-wide, which would pull in unrelated apps (parca-agent, pyrra, ...).
         podMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
         serviceMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
+        resources+: {
+          requests+: { cpu: '500m' },
+        },
+        containers: [
+          {
+            name: 'prometheus',
+            livenessProbe: { timeoutSeconds: 10, periodSeconds: 10, failureThreshold: 12 },
+            readinessProbe: { timeoutSeconds: 10, periodSeconds: 10, failureThreshold: 12 },
+          },
+        ],
         query+: {
           lookbackDelta: '15m',  // Analytics are only sent once every 10m
         },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -54,11 +54,7 @@ traefik:
 
   resources:
     requests:
-      cpu: 100m
+      cpu: 2
       memory: 256Mi
     limits:
-      # Still OOMKilled once at 2Gi under the full cutover traffic. Bounded
-      # rather than unlimited/near-node-capacity: this node also runs
-      # production parca, argocd, cert-manager, etc, so a real leak here
-      # should get contained rather than starve the whole node.
       memory: 4Gi


### PR DESCRIPTION
Traefik had no CPU request, so the scheduler co-located it with parca-analytics' Prometheus on the same node with no accounting for its real ~3-core usage under full production traffic. That Prometheus lost the CPU-contention race at its 100m request, its liveness/readiness probes kept timing out, and it restarted (with a ~10s WAL replay each time) in a tight loop.

Gives Traefik a real CPU request, bumps the Prometheus's, and relaxes its probes so a brief contention spike doesn't immediately trigger a restart.