### PR TITLE
fix(traefik): scale to 2 replicas

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -3,6 +3,19 @@ traefik:
   # the nginx.ingress.kubernetes.io/* annotations natively, running in parallel with
   # ingress-nginx until the DNS cutover.
   # https://doc.traefik.io/traefik/migrate/nginx-to-traefik/
+  deployment:
+    replicas: 2
+
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+          topologyKey: kubernetes.io/hostname
+
   providers:
     kubernetesIngressNGINX:
       enabled: true
@@ -54,7 +67,7 @@ traefik:
 
   resources:
     requests:
-      cpu: 2
+      cpu: 1
       memory: 256Mi
     limits:
       memory: 4Gi


### PR DESCRIPTION
It's been running the same production load ingress-nginx handled with 2 replicas on just 1, and just OOM/CPU-restarted 7 times in 30 minutes (load avg 8.5 on 4 cores at the time). Splits the same total CPU request across 2 pods with anti-affinity so they land on different nodes, giving both headroom and redundancy against the next restart.