### PR TITLE
feat(monitoring,traefik): mirror parca-analytics remote-write to Polar Signals Cloud

### DIFF
--- a/.schemas/Makefile
+++ b/.schemas/Makefile
@@ -17,6 +17,10 @@ CRDS := \
 	https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.85.0/jsonnet/prometheus-operator/prometheuses-crd.json \
 	https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.85.0/jsonnet/prometheus-operator/prometheusrules-crd.json \
 	https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.85.0/jsonnet/prometheus-operator/servicemonitors-crd.json \
+	https://raw.githubusercontent.com/traefik/traefik-helm-chart/v41.0.0/traefik/crds/traefik.io_ingressroutes.yaml \
+	https://raw.githubusercontent.com/traefik/traefik-helm-chart/v41.0.0/traefik/crds/traefik.io_middlewares.yaml \
+	https://raw.githubusercontent.com/traefik/traefik-helm-chart/v41.0.0/traefik/crds/traefik.io_traefikservices.yaml \
+	https://raw.githubusercontent.com/traefik/traefik-helm-chart/v41.0.0/traefik/crds/traefik.io_serverstransports.yaml \
 
 all: schemas
 

--- a/.schemas/ingressroute-traefik-v1alpha1.json
+++ b/.schemas/ingressroute-traefik-v1alpha1.json
@@ -1,0 +1,488 @@
+{
+  "description": "IngressRoute is the CRD implementation of a Traefik HTTP Router.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "IngressRouteSpec defines the desired state of IngressRoute.",
+      "properties": {
+        "entryPoints": {
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/install-configuration/entrypoints/\nDefault: all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ingressClassName": {
+          "description": "IngressClassName defines the name of the IngressClass cluster resource.",
+          "type": "string"
+        },
+        "parentRefs": {
+          "description": "ParentRefs defines references to parent IngressRoute resources for multi-layer routing.\nWhen set, this IngressRoute's routers will be children of the referenced parent IngressRoute's routers.\nMore info: https://doc.traefik.io/traefik/v3.7/routing/routers/#parentrefs",
+          "items": {
+            "description": "IngressRouteRef is a reference to an IngressRoute resource.",
+            "properties": {
+              "name": {
+                "description": "Name defines the name of the referenced IngressRoute resource.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace defines the namespace of the referenced IngressRoute resource.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "routes": {
+          "description": "Routes defines the list of routes.",
+          "items": {
+            "description": "Route holds the HTTP route configuration.",
+            "properties": {
+              "kind": {
+                "description": "Kind defines the kind of the route.\nRule is the only supported kind.\nIf not defined, defaults to Rule.",
+                "enum": [
+                  "Rule"
+                ],
+                "type": "string"
+              },
+              "match": {
+                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/",
+                "type": "string"
+              },
+              "middlewares": {
+                "description": "Middlewares defines the list of references to Middleware resources.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/middleware/",
+                "items": {
+                  "description": "MiddlewareRef is a reference to a Middleware resource.",
+                  "properties": {
+                    "name": {
+                      "description": "Name defines the name of the referenced Middleware resource.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "observability": {
+                "description": "Observability defines the observability configuration for a router.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/observability/",
+                "properties": {
+                  "accessLogs": {
+                    "description": "AccessLogs enables access logs for this router.",
+                    "type": "boolean"
+                  },
+                  "metrics": {
+                    "description": "Metrics enables metrics for this router.",
+                    "type": "boolean"
+                  },
+                  "traceVerbosity": {
+                    "default": "minimal",
+                    "description": "TraceVerbosity defines the verbosity level of the tracing for this router.",
+                    "enum": [
+                      "minimal",
+                      "detailed"
+                    ],
+                    "type": "string"
+                  },
+                  "tracing": {
+                    "description": "Tracing enables tracing for this router.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "priority": {
+                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#priority",
+                "maximum": 9223372036854775000,
+                "type": "integer"
+              },
+              "services": {
+                "description": "Services defines the list of Service.\nIt can contain any combination of TraefikService and/or reference to a Kubernetes Service.",
+                "items": {
+                  "description": "Service defines an upstream HTTP service to proxy traffic to.",
+                  "properties": {
+                    "healthCheck": {
+                      "description": "Healthcheck defines health checks for ExternalName services.",
+                      "properties": {
+                        "followRedirects": {
+                          "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                          "type": "boolean"
+                        },
+                        "headers": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                          "type": "object"
+                        },
+                        "hostname": {
+                          "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                          "type": "string"
+                        },
+                        "interval": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "method": {
+                          "description": "Method defines the healthcheck method.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path defines the server URL path for the health check endpoint.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port defines the server URL port for the health check endpoint.",
+                          "type": "integer"
+                        },
+                        "scheme": {
+                          "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                          "type": "integer"
+                        },
+                        "timeout": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "unhealthyInterval": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kind": {
+                      "description": "Kind defines the kind of the Service.",
+                      "enum": [
+                        "Service",
+                        "TraefikService"
+                      ],
+                      "type": "string"
+                    },
+                    "middlewares": {
+                      "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                      "items": {
+                        "description": "MiddlewareRef is a reference to a Middleware resource.",
+                        "properties": {
+                          "name": {
+                            "description": "Name defines the name of the referenced Middleware resource.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                      "type": "string"
+                    },
+                    "nativeLB": {
+                      "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                      "type": "boolean"
+                    },
+                    "nodePortLB": {
+                      "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                      "type": "boolean"
+                    },
+                    "passHostHeader": {
+                      "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                      "type": "boolean"
+                    },
+                    "passiveHealthCheck": {
+                      "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                      "properties": {
+                        "failureWindow": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "maxFailedAttempts": {
+                          "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "responseForwarding": {
+                      "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                      "properties": {
+                        "flushInterval": {
+                          "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scheme": {
+                      "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                      "type": "string"
+                    },
+                    "serversTransport": {
+                      "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                      "type": "string"
+                    },
+                    "sticky": {
+                      "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                      "properties": {
+                        "cookie": {
+                          "description": "Cookie defines the sticky cookie configuration.",
+                          "properties": {
+                            "domain": {
+                              "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                              "type": "string"
+                            },
+                            "httpOnly": {
+                              "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                              "type": "boolean"
+                            },
+                            "maxAge": {
+                              "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "description": "Name defines the Cookie name.",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                              "type": "string"
+                            },
+                            "sameSite": {
+                              "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                              "enum": [
+                                "none",
+                                "lax",
+                                "strict",
+                                "None",
+                                "Lax",
+                                "Strict"
+                              ],
+                              "type": "string"
+                            },
+                            "secure": {
+                              "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "strategy": {
+                      "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                      "enum": [
+                        "wrr",
+                        "p2c",
+                        "hrw",
+                        "leasttime",
+                        "RoundRobin"
+                      ],
+                      "type": "string"
+                    },
+                    "weight": {
+                      "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "syntax": {
+                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax\n\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "match"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "tls": {
+          "description": "TLS defines the TLS configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/router/#tls",
+          "properties": {
+            "certResolver": {
+              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/install-configuration/tls/certificate-resolvers/acme/",
+              "type": "string"
+            },
+            "domains": {
+              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/tls/tls-certificates/#domains",
+              "items": {
+                "description": "Domain holds a domain name with SANs.",
+                "properties": {
+                  "main": {
+                    "description": "Main defines the main domain name.",
+                    "type": "string"
+                  },
+                  "sans": {
+                    "description": "SANs defines the subject alternative domain names.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "options": {
+              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/tls/tls-options/",
+              "properties": {
+                "name": {
+                  "description": "Name defines the name of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/tlsoption/",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the namespace of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/tlsoption/",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretName": {
+              "description": "SecretName is the name of the referenced Kubernetes Secret to specify the certificate details.",
+              "type": "string"
+            },
+            "store": {
+              "description": "Store defines the reference to the TLSStore, that will be used to store certificates.\nPlease note that only `default` TLSStore can be used.",
+              "properties": {
+                "name": {
+                  "description": "Name defines the name of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/tlsstore/",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the namespace of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/tlsstore/",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "routes"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/middleware-traefik-v1alpha1.json
+++ b/.schemas/middleware-traefik-v1alpha1.json
@@ -1,0 +1,1418 @@
+{
+  "description": "Middleware is the CRD implementation of a Traefik Middleware.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/overview/",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MiddlewareSpec defines the desired state of a Middleware.",
+      "properties": {
+        "addPrefix": {
+          "description": "AddPrefix holds the add prefix middleware configuration.\nThis middleware updates the path of a request before forwarding it.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/addprefix/",
+          "properties": {
+            "prefix": {
+              "description": "Prefix is the string to add before the current path in the requested URL.\nIt should include a leading slash (/).",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "must start with a '/'",
+                  "rule": "self.startsWith('/')"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "basicAuth": {
+          "description": "BasicAuth holds the basic auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/basicauth/",
+          "properties": {
+            "headerField": {
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/basicauth/#headerfield",
+              "type": "string"
+            },
+            "realm": {
+              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.\nDefault: traefik.",
+              "type": "string"
+            },
+            "removeHeader": {
+              "description": "RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.\nDefault: false.",
+              "type": "boolean"
+            },
+            "secret": {
+              "description": "Secret is the name of the referenced Kubernetes Secret containing user credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "buffering": {
+          "description": "Buffering holds the buffering middleware configuration.\nThis middleware retries or limits the size of requests that can be forwarded to backends.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/buffering/#maxrequestbodybytes",
+          "properties": {
+            "maxRequestBodyBytes": {
+              "description": "MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).\nIf the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.\nDefault: 0 (no maximum).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxResponseBodyBytes": {
+              "description": "MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).\nIf the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.\nDefault: 0 (no maximum).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "memRequestBodyBytes": {
+              "description": "MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.\nDefault: 1048576 (1Mi).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "memResponseBodyBytes": {
+              "description": "MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.\nDefault: 1048576 (1Mi).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "retryExpression": {
+              "description": "RetryExpression defines the retry conditions.\nIt is a logical combination of functions with operators AND (&&) and OR (||).\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/buffering/#retryexpression",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "chain": {
+          "description": "Chain holds the configuration of the chain middleware.\nThis middleware enables to define reusable combinations of other pieces of middleware.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/chain/",
+          "properties": {
+            "middlewares": {
+              "description": "Middlewares is the list of MiddlewareRef which composes the chain.",
+              "items": {
+                "description": "MiddlewareRef is a reference to a Middleware resource.",
+                "properties": {
+                  "name": {
+                    "description": "Name defines the name of the referenced Middleware resource.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "circuitBreaker": {
+          "description": "CircuitBreaker holds the circuit breaker configuration.",
+          "properties": {
+            "checkPeriod": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "CheckPeriod is the interval between successive checks of the circuit breaker condition (when in standby state).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "expression": {
+              "description": "Expression is the condition that triggers the tripped state.",
+              "type": "string"
+            },
+            "fallbackDuration": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "FallbackDuration is the duration for which the circuit breaker will wait before trying to recover (from a tripped state).",
+              "x-kubernetes-int-or-string": true
+            },
+            "recoveryDuration": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "RecoveryDuration is the duration for which the circuit breaker will try to recover (as soon as it is in recovering state).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "responseCode": {
+              "description": "ResponseCode is the status code that the circuit breaker will return while it is in the open state.",
+              "maximum": 599,
+              "minimum": 100,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "compress": {
+          "description": "Compress holds the compress middleware configuration.\nThis middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/compress/",
+          "properties": {
+            "defaultEncoding": {
+              "description": "DefaultEncoding specifies the default encoding if the `Accept-Encoding` header is not in the request or contains a wildcard (`*`).",
+              "type": "string"
+            },
+            "encodings": {
+              "description": "Encodings defines the list of supported compression algorithms.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "excludedContentTypes": {
+              "description": "ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.\n`application/grpc` is always excluded.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "includedContentTypes": {
+              "description": "IncludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "minResponseBodyBytes": {
+              "description": "MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.\nDefault: 1024.",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "contentType": {
+          "description": "ContentType holds the content-type middleware configuration.\nThis middleware exists to enable the correct behavior until at least the default one can be changed in a future version.",
+          "properties": {
+            "autoDetect": {
+              "description": "AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,\nbe automatically set to a value derived from the contents of the response.\n\nDeprecated: AutoDetect option is deprecated, Content-Type middleware is only meant to be used to enable the content-type detection, please remove any usage of this option.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "digestAuth": {
+          "description": "DigestAuth holds the digest auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/digestauth/",
+          "properties": {
+            "headerField": {
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/digestauth/#headerfield",
+              "type": "string"
+            },
+            "realm": {
+              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.\nDefault: traefik.",
+              "type": "string"
+            },
+            "removeHeader": {
+              "description": "RemoveHeader defines whether to remove the authorization header before forwarding the request to the backend.",
+              "type": "boolean"
+            },
+            "secret": {
+              "description": "Secret is the name of the referenced Kubernetes Secret containing user credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "encodedCharacters": {
+          "description": "EncodedCharacters configures which encoded characters are allowed in the request path.",
+          "properties": {
+            "allowEncodedBackSlash": {
+              "description": "AllowEncodedBackSlash defines whether requests with encoded back slash characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedHash": {
+              "description": "AllowEncodedHash defines whether requests with encoded hash characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedNullCharacter": {
+              "description": "AllowEncodedNullCharacter defines whether requests with encoded null characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedPercent": {
+              "description": "AllowEncodedPercent defines whether requests with encoded percent characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedQuestionMark": {
+              "description": "AllowEncodedQuestionMark defines whether requests with encoded question mark characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedSemicolon": {
+              "description": "AllowEncodedSemicolon defines whether requests with encoded semicolon characters in the path are allowed.",
+              "type": "boolean"
+            },
+            "allowEncodedSlash": {
+              "description": "AllowEncodedSlash defines whether requests with encoded slash characters in the path are allowed.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "errors": {
+          "description": "ErrorPage holds the custom error middleware configuration.\nThis middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/errorpages/",
+          "properties": {
+            "query": {
+              "description": "Query defines the URL for the error page (hosted by service).\nThe {status} variable can be used in order to insert the status code in the URL.\nThe {originalStatus} variable can be used in order to insert the upstream status code in the URL.\nThe {url} variable can be used in order to insert the escaped request URL.",
+              "type": "string"
+            },
+            "service": {
+              "description": "Service defines the reference to a Kubernetes Service that will serve the error page.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/errorpages/#service",
+              "properties": {
+                "healthCheck": {
+                  "description": "Healthcheck defines health checks for ExternalName services.",
+                  "properties": {
+                    "followRedirects": {
+                      "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                      "type": "object"
+                    },
+                    "hostname": {
+                      "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                      "type": "string"
+                    },
+                    "interval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "method": {
+                      "description": "Method defines the healthcheck method.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path defines the server URL path for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port defines the server URL port for the health check endpoint.",
+                      "type": "integer"
+                    },
+                    "scheme": {
+                      "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                      "type": "integer"
+                    },
+                    "timeout": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "unhealthyInterval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind defines the kind of the Service.",
+                  "enum": [
+                    "Service",
+                    "TraefikService"
+                  ],
+                  "type": "string"
+                },
+                "middlewares": {
+                  "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                  "items": {
+                    "description": "MiddlewareRef is a reference to a Middleware resource.",
+                    "properties": {
+                      "name": {
+                        "description": "Name defines the name of the referenced Middleware resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                  "type": "string"
+                },
+                "nativeLB": {
+                  "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                  "type": "boolean"
+                },
+                "nodePortLB": {
+                  "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                  "type": "boolean"
+                },
+                "passHostHeader": {
+                  "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                  "type": "boolean"
+                },
+                "passiveHealthCheck": {
+                  "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                  "properties": {
+                    "failureWindow": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxFailedAttempts": {
+                      "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseForwarding": {
+                  "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                  "properties": {
+                    "flushInterval": {
+                      "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheme": {
+                  "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                  "type": "string"
+                },
+                "serversTransport": {
+                  "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                  "type": "string"
+                },
+                "sticky": {
+                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                  "properties": {
+                    "cookie": {
+                      "description": "Cookie defines the sticky cookie configuration.",
+                      "properties": {
+                        "domain": {
+                          "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                          "type": "string"
+                        },
+                        "httpOnly": {
+                          "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                          "type": "boolean"
+                        },
+                        "maxAge": {
+                          "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "description": "Name defines the Cookie name.",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                          "type": "string"
+                        },
+                        "sameSite": {
+                          "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                          "enum": [
+                            "none",
+                            "lax",
+                            "strict",
+                            "None",
+                            "Lax",
+                            "Strict"
+                          ],
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "strategy": {
+                  "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                  "enum": [
+                    "wrr",
+                    "p2c",
+                    "hrw",
+                    "leasttime",
+                    "RoundRobin"
+                  ],
+                  "type": "string"
+                },
+                "weight": {
+                  "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "description": "Status defines which status or range of statuses should result in an error page.\nIt can be either a status code as a number (500),\nas multiple comma-separated numbers (500,502),\nas ranges by separating two codes with a dash (500-599),\nor a combination of the two (404,418,500-599).",
+              "items": {
+                "pattern": "^([1-5][0-9]{2}[,-]?)+$",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "statusRewrites": {
+              "additionalProperties": {
+                "type": "integer"
+              },
+              "description": "StatusRewrites defines a mapping of status codes that should be returned instead of the original error status codes.\nFor example: \"418\": 404 or \"410-418\": 404",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forwardAuth": {
+          "description": "ForwardAuth holds the forward auth middleware configuration.\nThis middleware delegates the request authentication to a Service.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/forwardauth/",
+          "properties": {
+            "addAuthCookiesToResponse": {
+              "description": "AddAuthCookiesToResponse defines the list of cookies to copy from the authentication server response to the response.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "address": {
+              "description": "Address defines the authentication server address.",
+              "type": "string"
+            },
+            "authRequestHeaders": {
+              "description": "AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.\nIf not set or empty then all request headers are passed.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authResponseHeaders": {
+              "description": "AuthResponseHeaders defines the list of headers to copy from the authentication server response and set on forwarded request, replacing any existing conflicting headers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authResponseHeadersRegex": {
+              "description": "AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/forwardauth/#authresponseheadersregex",
+              "type": "string"
+            },
+            "authSigninURL": {
+              "description": "AuthSigninURL specifies the URL to redirect to when the authentication server returns 401 Unauthorized.",
+              "type": "string"
+            },
+            "forwardBody": {
+              "description": "ForwardBody defines whether to send the request body to the authentication server.",
+              "type": "boolean"
+            },
+            "headerField": {
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/forwardauth/#headerfield",
+              "type": "string"
+            },
+            "maxBodySize": {
+              "description": "MaxBodySize defines the maximum body size in bytes allowed to be forwarded to the authentication server.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxResponseBodySize": {
+              "description": "MaxResponseBodySize defines the maximum body size in bytes allowed in the response from the authentication server.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "preserveLocationHeader": {
+              "description": "PreserveLocationHeader defines whether to forward the Location header to the client as is or prefix it with the domain name of the authentication server.",
+              "type": "boolean"
+            },
+            "preserveRequestMethod": {
+              "description": "PreserveRequestMethod defines whether to preserve the original request method while forwarding the request to the authentication server.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "TLS defines the configuration used to secure the connection to the authentication server.",
+              "properties": {
+                "caOptional": {
+                  "description": "Deprecated: TLS client authentication is a server side option (see https://github.com/golang/go/blob/740a490f71d026bb7d2d13cb8fa2d6d6e0572b70/src/crypto/tls/common.go#L634).",
+                  "type": "boolean"
+                },
+                "caSecret": {
+                  "description": "CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.\nThe CA certificate is extracted from key `tls.ca` or `ca.crt`.",
+                  "type": "string"
+                },
+                "certSecret": {
+                  "description": "CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.\nThe client certificate is extracted from the keys `tls.crt` and `tls.key`.",
+                  "type": "string"
+                },
+                "insecureSkipVerify": {
+                  "description": "InsecureSkipVerify defines whether the server certificates should be validated.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "trustForwardHeader": {
+              "description": "TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.\n\nDeprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "grpcWeb": {
+          "description": "GrpcWeb holds the gRPC web middleware configuration.\nThis middleware converts a gRPC web request to an HTTP/2 gRPC request.",
+          "properties": {
+            "allowOrigins": {
+              "description": "AllowOrigins is a list of allowable origins.\nCan also be a wildcard origin \"*\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headers": {
+          "description": "Headers holds the headers middleware configuration.\nThis middleware manages the requests and responses headers.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/headers/#customrequestheaders",
+          "properties": {
+            "accessControlAllowCredentials": {
+              "description": "AccessControlAllowCredentials defines whether the request can include user credentials.",
+              "type": "boolean"
+            },
+            "accessControlAllowHeaders": {
+              "description": "AccessControlAllowHeaders defines the Access-Control-Request-Headers values sent in preflight response.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accessControlAllowMethods": {
+              "description": "AccessControlAllowMethods defines the Access-Control-Request-Method values sent in preflight response.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accessControlAllowOriginList": {
+              "description": "AccessControlAllowOriginList is a list of allowable origins. Can also be a wildcard origin \"*\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accessControlAllowOriginListRegex": {
+              "description": "AccessControlAllowOriginListRegex is a list of allowable origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accessControlExposeHeaders": {
+              "description": "AccessControlExposeHeaders defines the Access-Control-Expose-Headers values sent in preflight response.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accessControlMaxAge": {
+              "description": "AccessControlMaxAge defines the time that a preflight request may be cached.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "addVaryHeader": {
+              "description": "AddVaryHeader defines whether the Vary header is automatically added/updated when the AccessControlAllowOriginList is set.",
+              "type": "boolean"
+            },
+            "allowedHosts": {
+              "description": "AllowedHosts defines the fully qualified list of allowed domain names.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "browserXssFilter": {
+              "description": "BrowserXSSFilter defines whether to add the X-XSS-Protection header with the value 1; mode=block.",
+              "type": "boolean"
+            },
+            "contentSecurityPolicy": {
+              "description": "ContentSecurityPolicy defines the Content-Security-Policy header value.",
+              "type": "string"
+            },
+            "contentSecurityPolicyReportOnly": {
+              "description": "ContentSecurityPolicyReportOnly defines the Content-Security-Policy-Report-Only header value.",
+              "type": "string"
+            },
+            "contentTypeNosniff": {
+              "description": "ContentTypeNosniff defines whether to add the X-Content-Type-Options header with the nosniff value.",
+              "type": "boolean"
+            },
+            "customBrowserXSSValue": {
+              "description": "CustomBrowserXSSValue defines the X-XSS-Protection header value.\nThis overrides the BrowserXssFilter option.",
+              "type": "string"
+            },
+            "customFrameOptionsValue": {
+              "description": "CustomFrameOptionsValue defines the X-Frame-Options header value.\nThis overrides the FrameDeny option.",
+              "type": "string"
+            },
+            "customRequestHeaders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "CustomRequestHeaders defines the header names and values to apply to the request.",
+              "type": "object"
+            },
+            "customResponseHeaders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "CustomResponseHeaders defines the header names and values to apply to the response.",
+              "type": "object"
+            },
+            "featurePolicy": {
+              "description": "Deprecated: FeaturePolicy option is deprecated, please use PermissionsPolicy instead.",
+              "type": "string"
+            },
+            "forceSTSHeader": {
+              "description": "ForceSTSHeader defines whether to add the STS header even when the connection is HTTP.",
+              "type": "boolean"
+            },
+            "frameDeny": {
+              "description": "FrameDeny defines whether to add the X-Frame-Options header with the DENY value.",
+              "type": "boolean"
+            },
+            "hostsProxyHeaders": {
+              "description": "HostsProxyHeaders defines the header keys that may hold a proxied hostname value for the request.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "isDevelopment": {
+              "description": "IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.\nUsually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.\nIf you would like your development environment to mimic production with complete Host blocking, SSL redirects,\nand STS headers, leave this as false.",
+              "type": "boolean"
+            },
+            "permissionsPolicy": {
+              "description": "PermissionsPolicy defines the Permissions-Policy header value.\nThis allows sites to control browser features.",
+              "type": "string"
+            },
+            "publicKey": {
+              "description": "PublicKey is the public key that implements HPKP to prevent MITM attacks with forged certificates.",
+              "type": "string"
+            },
+            "referrerPolicy": {
+              "description": "ReferrerPolicy defines the Referrer-Policy header value.\nThis allows sites to control whether browsers forward the Referer header to other sites.",
+              "type": "string"
+            },
+            "sslForceHost": {
+              "description": "Deprecated: SSLForceHost option is deprecated, please use RedirectRegex instead.",
+              "type": "boolean"
+            },
+            "sslHost": {
+              "description": "Deprecated: SSLHost option is deprecated, please use RedirectRegex instead.",
+              "type": "string"
+            },
+            "sslProxyHeaders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.\nIt can be useful when using other proxies (example: \"X-Forwarded-Proto\": \"https\").",
+              "type": "object"
+            },
+            "sslRedirect": {
+              "description": "Deprecated: SSLRedirect option is deprecated, please use EntryPoint redirection or RedirectScheme instead.",
+              "type": "boolean"
+            },
+            "sslTemporaryRedirect": {
+              "description": "Deprecated: SSLTemporaryRedirect option is deprecated, please use EntryPoint redirection or RedirectScheme instead.",
+              "type": "boolean"
+            },
+            "stsIncludeSubdomains": {
+              "description": "STSIncludeSubdomains defines whether the includeSubDomains directive is appended to the Strict-Transport-Security header.",
+              "type": "boolean"
+            },
+            "stsPreload": {
+              "description": "STSPreload defines whether the preload flag is appended to the Strict-Transport-Security header.",
+              "type": "boolean"
+            },
+            "stsSeconds": {
+              "description": "STSSeconds defines the max-age of the Strict-Transport-Security header.\nIf set to 0, the header is not set.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "inFlightReq": {
+          "description": "InFlightReq holds the in-flight request middleware configuration.\nThis middleware limits the number of requests being processed and served concurrently.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/inflightreq/",
+          "properties": {
+            "amount": {
+              "description": "Amount defines the maximum amount of allowed simultaneous in-flight request.\nThe middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sourceCriterion": {
+              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the requestHost.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/inflightreq/#sourcecriterion",
+              "properties": {
+                "ipStrategy": {
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/ipallowlist/#ipstrategy",
+                  "properties": {
+                    "depth": {
+                      "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "excludedIPs": {
+                      "description": "ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ipv6Subnet": {
+                      "description": "IPv6Subnet configures Traefik to consider all IPv6 addresses from the defined subnet as originating from the same IP. Applies to RemoteAddrStrategy and DepthStrategy.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "requestHeaderName": {
+                  "description": "RequestHeaderName defines the name of the header used to group incoming requests.",
+                  "type": "string"
+                },
+                "requestHost": {
+                  "description": "RequestHost defines whether to consider the request Host as the source.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ipAllowList": {
+          "description": "IPAllowList holds the IP allowlist middleware configuration.\nThis middleware limits allowed requests based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/ipallowlist/",
+          "properties": {
+            "ipStrategy": {
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/ipallowlist/#ipstrategy",
+              "properties": {
+                "depth": {
+                  "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "excludedIPs": {
+                  "description": "ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipv6Subnet": {
+                  "description": "IPv6Subnet configures Traefik to consider all IPv6 addresses from the defined subnet as originating from the same IP. Applies to RemoteAddrStrategy and DepthStrategy.",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rejectStatusCode": {
+              "description": "RejectStatusCode defines the HTTP status code used for refused requests.\nIf not set, the default is 403 (Forbidden).",
+              "type": "integer"
+            },
+            "sourceRange": {
+              "description": "SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ipWhiteList": {
+          "description": "Deprecated: please use IPAllowList instead.",
+          "properties": {
+            "ipStrategy": {
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/ipallowlist/#ipstrategy",
+              "properties": {
+                "depth": {
+                  "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "excludedIPs": {
+                  "description": "ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipv6Subnet": {
+                  "description": "IPv6Subnet configures Traefik to consider all IPv6 addresses from the defined subnet as originating from the same IP. Applies to RemoteAddrStrategy and DepthStrategy.",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sourceRange": {
+              "description": "SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation). Required.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "passTLSClientCert": {
+          "description": "PassTLSClientCert holds the pass TLS client cert middleware configuration.\nThis middleware adds the selected data from the passed client TLS certificate to a header.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/passtlsclientcert/",
+          "properties": {
+            "info": {
+              "description": "Info selects the specific client certificate details you want to add to the X-Forwarded-Tls-Client-Cert-Info header.",
+              "properties": {
+                "issuer": {
+                  "description": "Issuer defines the client certificate issuer details to add to the X-Forwarded-Tls-Client-Cert-Info header.",
+                  "properties": {
+                    "commonName": {
+                      "description": "CommonName defines whether to add the organizationalUnit information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "country": {
+                      "description": "Country defines whether to add the country information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "domainComponent": {
+                      "description": "DomainComponent defines whether to add the domainComponent information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "locality": {
+                      "description": "Locality defines whether to add the locality information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "organization": {
+                      "description": "Organization defines whether to add the organization information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "province": {
+                      "description": "Province defines whether to add the province information into the issuer.",
+                      "type": "boolean"
+                    },
+                    "serialNumber": {
+                      "description": "SerialNumber defines whether to add the serialNumber information into the issuer.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "notAfter": {
+                  "description": "NotAfter defines whether to add the Not After information from the Validity part.",
+                  "type": "boolean"
+                },
+                "notBefore": {
+                  "description": "NotBefore defines whether to add the Not Before information from the Validity part.",
+                  "type": "boolean"
+                },
+                "sans": {
+                  "description": "Sans defines whether to add the Subject Alternative Name information from the Subject Alternative Name part.",
+                  "type": "boolean"
+                },
+                "serialNumber": {
+                  "description": "SerialNumber defines whether to add the client serialNumber information.",
+                  "type": "boolean"
+                },
+                "subject": {
+                  "description": "Subject defines the client certificate subject details to add to the X-Forwarded-Tls-Client-Cert-Info header.",
+                  "properties": {
+                    "commonName": {
+                      "description": "CommonName defines whether to add the organizationalUnit information into the subject.",
+                      "type": "boolean"
+                    },
+                    "country": {
+                      "description": "Country defines whether to add the country information into the subject.",
+                      "type": "boolean"
+                    },
+                    "domainComponent": {
+                      "description": "DomainComponent defines whether to add the domainComponent information into the subject.",
+                      "type": "boolean"
+                    },
+                    "locality": {
+                      "description": "Locality defines whether to add the locality information into the subject.",
+                      "type": "boolean"
+                    },
+                    "organization": {
+                      "description": "Organization defines whether to add the organization information into the subject.",
+                      "type": "boolean"
+                    },
+                    "organizationalUnit": {
+                      "description": "OrganizationalUnit defines whether to add the organizationalUnit information into the subject.",
+                      "type": "boolean"
+                    },
+                    "province": {
+                      "description": "Province defines whether to add the province information into the subject.",
+                      "type": "boolean"
+                    },
+                    "serialNumber": {
+                      "description": "SerialNumber defines whether to add the serialNumber information into the subject.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "pem": {
+              "description": "PEM sets the X-Forwarded-Tls-Client-Cert header with the certificate.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "plugin": {
+          "additionalProperties": {
+            "x-kubernetes-preserve-unknown-fields": true
+          },
+          "description": "Plugin defines the middleware plugin configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/overview/#community-middlewares",
+          "type": "object"
+        },
+        "rateLimit": {
+          "description": "RateLimit holds the rate limit configuration.\nThis middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/ratelimit/",
+          "properties": {
+            "average": {
+              "description": "Average is the maximum rate, by default in requests/s, allowed for the given source.\nIt defaults to 0, which means no rate limiting.\nThe rate is actually defined by dividing Average by Period. So for a rate below 1req/s,\none needs to define a Period larger than a second.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "burst": {
+              "description": "Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.\nIt defaults to 1.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "period": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Period, in combination with Average, defines the actual maximum rate, such as:\nr = Average / Period. It defaults to a second.",
+              "x-kubernetes-int-or-string": true
+            },
+            "redis": {
+              "description": "Redis hold the configs of Redis as bucket in rate limiter.",
+              "properties": {
+                "db": {
+                  "description": "DB defines the Redis database that will be selected after connecting to the server.",
+                  "type": "integer"
+                },
+                "dialTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "DialTimeout sets the timeout for establishing new connections.\nDefault value is 5 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "endpoints": {
+                  "description": "Endpoints contains either a single address or a seed list of host:port addresses.\nDefault value is [\"localhost:6379\"].",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxActiveConns": {
+                  "description": "MaxActiveConns defines the maximum number of connections allocated by the pool at a given time.\nDefault value is 0, meaning there is no limit.",
+                  "type": "integer"
+                },
+                "minIdleConns": {
+                  "description": "MinIdleConns defines the minimum number of idle connections.\nDefault value is 0, and idle connections are not closed by default.",
+                  "type": "integer"
+                },
+                "poolSize": {
+                  "description": "PoolSize defines the initial number of socket connections.\nIf the pool runs out of available connections, additional ones will be created beyond PoolSize.\nThis can be limited using MaxActiveConns.\n// Default value is 0, meaning 10 connections per every available CPU as reported by runtime.GOMAXPROCS.",
+                  "type": "integer"
+                },
+                "readTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "ReadTimeout defines the timeout for socket read operations.\nDefault value is 3 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "secret": {
+                  "description": "Secret defines the name of the referenced Kubernetes Secret containing Redis credentials.",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "TLS defines TLS-specific configurations, including the CA, certificate, and key,\nwhich can be provided as a file path or file content.",
+                  "properties": {
+                    "caSecret": {
+                      "description": "CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.\nThe CA certificate is extracted from key `tls.ca` or `ca.crt`.",
+                      "type": "string"
+                    },
+                    "certSecret": {
+                      "description": "CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.\nThe client certificate is extracted from the keys `tls.crt` and `tls.key`.",
+                      "type": "string"
+                    },
+                    "insecureSkipVerify": {
+                      "description": "InsecureSkipVerify defines whether the server certificates should be validated.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "writeTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "WriteTimeout defines the timeout for socket write operations.\nDefault value is 3 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sourceCriterion": {
+              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the request's remote address field (as an ipStrategy).",
+              "properties": {
+                "ipStrategy": {
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/ipallowlist/#ipstrategy",
+                  "properties": {
+                    "depth": {
+                      "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "excludedIPs": {
+                      "description": "ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ipv6Subnet": {
+                      "description": "IPv6Subnet configures Traefik to consider all IPv6 addresses from the defined subnet as originating from the same IP. Applies to RemoteAddrStrategy and DepthStrategy.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "requestHeaderName": {
+                  "description": "RequestHeaderName defines the name of the header used to group incoming requests.",
+                  "type": "string"
+                },
+                "requestHost": {
+                  "description": "RequestHost defines whether to consider the request Host as the source.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "redirectRegex": {
+          "description": "RedirectRegex holds the redirect regex middleware configuration.\nThis middleware redirects a request using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/redirectregex/#regex",
+          "properties": {
+            "permanent": {
+              "description": "Permanent defines whether the redirection is permanent (308).",
+              "type": "boolean"
+            },
+            "regex": {
+              "description": "Regex defines the regex used to match and capture elements from the request URL.",
+              "type": "string"
+            },
+            "replacement": {
+              "description": "Replacement defines how to modify the URL to have the new target URL.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "redirectScheme": {
+          "description": "RedirectScheme holds the redirect scheme middleware configuration.\nThis middleware redirects requests from a scheme/port to another.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/redirectscheme/",
+          "properties": {
+            "permanent": {
+              "description": "Permanent defines whether the redirection is permanent.\nFor HTTP GET requests a 301 is returned, otherwise a 308 is returned.",
+              "type": "boolean"
+            },
+            "port": {
+              "description": "Port defines the port of the new URL.",
+              "type": "string"
+            },
+            "scheme": {
+              "description": "Scheme defines the scheme of the new URL.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replacePath": {
+          "description": "ReplacePath holds the replace path middleware configuration.\nThis middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/replacepath/",
+          "properties": {
+            "path": {
+              "description": "Path defines the path to use as replacement in the request URL.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replacePathRegex": {
+          "description": "ReplacePathRegex holds the replace path regex middleware configuration.\nThis middleware replaces the path of a URL using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/replacepathregex/",
+          "properties": {
+            "regex": {
+              "description": "Regex defines the regular expression used to match and capture the path from the request URL.",
+              "type": "string"
+            },
+            "replacement": {
+              "description": "Replacement defines the replacement path format, which can include captured variables.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry": {
+          "description": "Retry holds the retry middleware configuration.\nThis middleware reissues requests a given number of times to a backend server if that server does not reply.\nAs soon as the server answers, the middleware stops retrying, regardless of the response status.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/retry/",
+          "properties": {
+            "attempts": {
+              "description": "Attempts defines how many times the request should be retried.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "disableRetryOnNetworkError": {
+              "description": "DisableRetryOnNetworkError defines whether to disable the retry if an error occurs when transmitting the request to the server.",
+              "type": "boolean"
+            },
+            "initialInterval": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "InitialInterval defines the first wait time in the exponential backoff series.\nThe maximum interval is calculated as twice the initialInterval.\nIf unspecified, requests will be retried immediately.\nThe value of initialInterval should be provided in seconds or as a valid duration format,\nsee https://pkg.go.dev/time#ParseDuration.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "maxRequestBodyBytes": {
+              "description": "MaxRequestBodyBytes defines the maximum size for the request body.\nDefault is `-1`, which means no limit.",
+              "format": "int64",
+              "minimum": -1,
+              "type": "integer"
+            },
+            "retryNonIdempotentMethod": {
+              "description": "RetryNonIdempotentMethod activates the retry for non-idempotent methods (POST, LOCK, PATCH)",
+              "type": "boolean"
+            },
+            "status": {
+              "description": "Status defines the range of HTTP status codes to retry on.",
+              "items": {
+                "pattern": "^([1-5][0-9]{2}[,-]?)+$",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "timeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Timeout defines how much time the middleware is allowed to retry the request.\nThe value of timeout should be provided in seconds or as a valid duration format,\nsee https://pkg.go.dev/time#ParseDuration.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stripPrefix": {
+          "description": "StripPrefix holds the strip prefix middleware configuration.\nThis middleware removes the specified prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/stripprefix/",
+          "properties": {
+            "forceSlash": {
+              "description": "Deprecated: ForceSlash option is deprecated, please remove any usage of this option.\nForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.\nDefault: true.",
+              "type": "boolean"
+            },
+            "prefixes": {
+              "description": "Prefixes defines the prefixes to strip from the request URL.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stripPrefixRegex": {
+          "description": "StripPrefixRegex holds the strip prefix regex middleware configuration.\nThis middleware removes the matching prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.7/middlewares/http/stripprefixregex/",
+          "properties": {
+            "regex": {
+              "description": "Regex defines the regular expression to match the path prefix from the request URL.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/serverstransport-traefik-v1alpha1.json
+++ b/.schemas/serverstransport-traefik-v1alpha1.json
@@ -1,0 +1,194 @@
+{
+  "description": "ServersTransport is the CRD implementation of a ServersTransport.\nIf no serversTransport is specified, the default@internal will be used.\nThe default@internal serversTransport is created from the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/serverstransport/",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ServersTransportSpec defines the desired state of a ServersTransport.",
+      "properties": {
+        "certificatesSecrets": {
+          "description": "CertificatesSecrets defines a list of secret storing client certificates for mTLS.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cipherSuites": {
+          "description": "CipherSuites defines the cipher suites to use when contacting backend servers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "disableHTTP2": {
+          "description": "DisableHTTP2 disables HTTP/2 for connections with backend servers.",
+          "type": "boolean"
+        },
+        "forwardingTimeouts": {
+          "description": "ForwardingTimeouts defines the timeouts for requests forwarded to the backend servers.",
+          "properties": {
+            "dialTimeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "DialTimeout is the amount of time to wait until a connection to a backend server can be established.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "idleConnTimeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "IdleConnTimeout is the maximum period for which an idle HTTP keep-alive connection will remain open before closing itself.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "pingTimeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "PingTimeout is the timeout after which the HTTP/2 connection will be closed if a response to ping is not received.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "readIdleTimeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "ReadIdleTimeout is the timeout after which a health check using ping frame will be carried out if no frame is received on the HTTP/2 connection.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            },
+            "responseHeaderTimeout": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "ResponseHeaderTimeout is the amount of time to wait for a server's response headers after fully writing the request (including its body, if any).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "insecureSkipVerify": {
+          "description": "InsecureSkipVerify disables SSL certificate verification.",
+          "type": "boolean"
+        },
+        "maxIdleConnsPerHost": {
+          "description": "MaxIdleConnsPerHost controls the maximum idle (keep-alive) to keep per-host.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "maxVersion": {
+          "description": "MaxVersion defines the maximum TLS version to use when contacting backend servers.",
+          "type": "string"
+        },
+        "minVersion": {
+          "description": "MinVersion defines the minimum TLS version to use when contacting backend servers.",
+          "type": "string"
+        },
+        "peerCertURI": {
+          "description": "PeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.",
+          "type": "string"
+        },
+        "rootCAs": {
+          "description": "RootCAs defines a list of CA certificate Secrets or ConfigMaps used to validate server certificates.",
+          "items": {
+            "description": "RootCA defines a reference to a Secret or a ConfigMap that holds a CA certificate.\nIf both a Secret and a ConfigMap reference are defined, the Secret reference takes precedence.",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap defines the name of a ConfigMap that holds a CA certificate.\nThe referenced ConfigMap must contain a certificate under either a tls.ca or a ca.crt key.",
+                "type": "string"
+              },
+              "secret": {
+                "description": "Secret defines the name of a Secret that holds a CA certificate.\nThe referenced Secret must contain a certificate under either a tls.ca or a ca.crt key.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "RootCA cannot have both Secret and ConfigMap defined.",
+                "rule": "!has(self.secret) || !has(self.configMap)"
+              }
+            ],
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "rootCAsSecrets": {
+          "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\n\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "serverName": {
+          "description": "ServerName defines the server name used to contact the server.",
+          "type": "string"
+        },
+        "spiffe": {
+          "description": "Spiffe defines the SPIFFE configuration.",
+          "properties": {
+            "ids": {
+              "description": "IDs defines the allowed SPIFFE IDs (takes precedence over the SPIFFE TrustDomain).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "trustDomain": {
+              "description": "TrustDomain defines the allowed SPIFFE trust domain.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/.schemas/traefikservice-traefik-v1alpha1.json
+++ b/.schemas/traefikservice-traefik-v1alpha1.json
@@ -1,0 +1,1721 @@
+{
+  "description": "TraefikService is the CRD implementation of a Traefik Service.\nTraefikService object allows to:\n- Apply weight to Services on load-balancing\n- Mirror traffic on services\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/traefikservice/",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TraefikServiceSpec defines the desired state of a TraefikService.",
+      "properties": {
+        "failover": {
+          "description": "Failover defines the Failover service configuration.",
+          "properties": {
+            "errors": {
+              "description": "Errors defines which errors should trigger the use of the fallback service.",
+              "properties": {
+                "maxRequestBodyBytes": {
+                  "description": "MaxRequestBodyBytes defines the maximum size allowed for the body of the request.\nDefault value is -1, which means unlimited size.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "status": {
+                  "description": "Status defines the list of status code ranges for which the fallback service should be used.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fallback": {
+              "description": "Fallback defines the fallback service to use when the main service returns an error.",
+              "properties": {
+                "healthCheck": {
+                  "description": "Healthcheck defines health checks for ExternalName services.",
+                  "properties": {
+                    "followRedirects": {
+                      "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                      "type": "object"
+                    },
+                    "hostname": {
+                      "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                      "type": "string"
+                    },
+                    "interval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "method": {
+                      "description": "Method defines the healthcheck method.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path defines the server URL path for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port defines the server URL port for the health check endpoint.",
+                      "type": "integer"
+                    },
+                    "scheme": {
+                      "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                      "type": "integer"
+                    },
+                    "timeout": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "unhealthyInterval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind defines the kind of the Service.",
+                  "enum": [
+                    "Service",
+                    "TraefikService"
+                  ],
+                  "type": "string"
+                },
+                "middlewares": {
+                  "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                  "items": {
+                    "description": "MiddlewareRef is a reference to a Middleware resource.",
+                    "properties": {
+                      "name": {
+                        "description": "Name defines the name of the referenced Middleware resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                  "type": "string"
+                },
+                "nativeLB": {
+                  "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                  "type": "boolean"
+                },
+                "nodePortLB": {
+                  "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                  "type": "boolean"
+                },
+                "passHostHeader": {
+                  "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                  "type": "boolean"
+                },
+                "passiveHealthCheck": {
+                  "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                  "properties": {
+                    "failureWindow": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxFailedAttempts": {
+                      "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseForwarding": {
+                  "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                  "properties": {
+                    "flushInterval": {
+                      "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheme": {
+                  "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                  "type": "string"
+                },
+                "serversTransport": {
+                  "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                  "type": "string"
+                },
+                "sticky": {
+                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                  "properties": {
+                    "cookie": {
+                      "description": "Cookie defines the sticky cookie configuration.",
+                      "properties": {
+                        "domain": {
+                          "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                          "type": "string"
+                        },
+                        "httpOnly": {
+                          "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                          "type": "boolean"
+                        },
+                        "maxAge": {
+                          "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "description": "Name defines the Cookie name.",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                          "type": "string"
+                        },
+                        "sameSite": {
+                          "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                          "enum": [
+                            "none",
+                            "lax",
+                            "strict",
+                            "None",
+                            "Lax",
+                            "Strict"
+                          ],
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "strategy": {
+                  "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                  "enum": [
+                    "wrr",
+                    "p2c",
+                    "hrw",
+                    "leasttime",
+                    "RoundRobin"
+                  ],
+                  "type": "string"
+                },
+                "weight": {
+                  "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "service": {
+              "description": "Service defines the main service to use.",
+              "properties": {
+                "healthCheck": {
+                  "description": "Healthcheck defines health checks for ExternalName services.",
+                  "properties": {
+                    "followRedirects": {
+                      "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                      "type": "object"
+                    },
+                    "hostname": {
+                      "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                      "type": "string"
+                    },
+                    "interval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "method": {
+                      "description": "Method defines the healthcheck method.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path defines the server URL path for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port defines the server URL port for the health check endpoint.",
+                      "type": "integer"
+                    },
+                    "scheme": {
+                      "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                      "type": "integer"
+                    },
+                    "timeout": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "unhealthyInterval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind defines the kind of the Service.",
+                  "enum": [
+                    "Service",
+                    "TraefikService"
+                  ],
+                  "type": "string"
+                },
+                "middlewares": {
+                  "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                  "items": {
+                    "description": "MiddlewareRef is a reference to a Middleware resource.",
+                    "properties": {
+                      "name": {
+                        "description": "Name defines the name of the referenced Middleware resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                  "type": "string"
+                },
+                "nativeLB": {
+                  "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                  "type": "boolean"
+                },
+                "nodePortLB": {
+                  "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                  "type": "boolean"
+                },
+                "passHostHeader": {
+                  "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                  "type": "boolean"
+                },
+                "passiveHealthCheck": {
+                  "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                  "properties": {
+                    "failureWindow": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxFailedAttempts": {
+                      "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseForwarding": {
+                  "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                  "properties": {
+                    "flushInterval": {
+                      "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheme": {
+                  "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                  "type": "string"
+                },
+                "serversTransport": {
+                  "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                  "type": "string"
+                },
+                "sticky": {
+                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                  "properties": {
+                    "cookie": {
+                      "description": "Cookie defines the sticky cookie configuration.",
+                      "properties": {
+                        "domain": {
+                          "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                          "type": "string"
+                        },
+                        "httpOnly": {
+                          "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                          "type": "boolean"
+                        },
+                        "maxAge": {
+                          "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "description": "Name defines the Cookie name.",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                          "type": "string"
+                        },
+                        "sameSite": {
+                          "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                          "enum": [
+                            "none",
+                            "lax",
+                            "strict",
+                            "None",
+                            "Lax",
+                            "Strict"
+                          ],
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "strategy": {
+                  "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                  "enum": [
+                    "wrr",
+                    "p2c",
+                    "hrw",
+                    "leasttime",
+                    "RoundRobin"
+                  ],
+                  "type": "string"
+                },
+                "weight": {
+                  "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "errors",
+            "fallback",
+            "service"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "highestRandomWeight": {
+          "description": "HighestRandomWeight defines the highest random weight service configuration.",
+          "properties": {
+            "services": {
+              "description": "Services defines the list of Kubernetes Service and/or TraefikService to load-balance, with weight.",
+              "items": {
+                "description": "Service defines an upstream HTTP service to proxy traffic to.",
+                "properties": {
+                  "healthCheck": {
+                    "description": "Healthcheck defines health checks for ExternalName services.",
+                    "properties": {
+                      "followRedirects": {
+                        "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                        "type": "boolean"
+                      },
+                      "headers": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                        "type": "object"
+                      },
+                      "hostname": {
+                        "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                        "type": "string"
+                      },
+                      "interval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "method": {
+                        "description": "Method defines the healthcheck method.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path defines the server URL path for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Port defines the server URL port for the health check endpoint.",
+                        "type": "integer"
+                      },
+                      "scheme": {
+                        "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                        "type": "integer"
+                      },
+                      "timeout": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "unhealthyInterval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kind": {
+                    "description": "Kind defines the kind of the Service.",
+                    "enum": [
+                      "Service",
+                      "TraefikService"
+                    ],
+                    "type": "string"
+                  },
+                  "middlewares": {
+                    "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                    "items": {
+                      "description": "MiddlewareRef is a reference to a Middleware resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name defines the name of the referenced Middleware resource.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                    "type": "string"
+                  },
+                  "nativeLB": {
+                    "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                    "type": "boolean"
+                  },
+                  "nodePortLB": {
+                    "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                    "type": "boolean"
+                  },
+                  "passHostHeader": {
+                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                    "type": "boolean"
+                  },
+                  "passiveHealthCheck": {
+                    "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                    "properties": {
+                      "failureWindow": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "maxFailedAttempts": {
+                        "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "responseForwarding": {
+                    "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                    "properties": {
+                      "flushInterval": {
+                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scheme": {
+                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                    "type": "string"
+                  },
+                  "serversTransport": {
+                    "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                    "type": "string"
+                  },
+                  "sticky": {
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                    "properties": {
+                      "cookie": {
+                        "description": "Cookie defines the sticky cookie configuration.",
+                        "properties": {
+                          "domain": {
+                            "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                            "type": "string"
+                          },
+                          "httpOnly": {
+                            "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                            "type": "boolean"
+                          },
+                          "maxAge": {
+                            "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name defines the Cookie name.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                            "type": "string"
+                          },
+                          "sameSite": {
+                            "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "enum": [
+                              "none",
+                              "lax",
+                              "strict",
+                              "None",
+                              "Lax",
+                              "Strict"
+                            ],
+                            "type": "string"
+                          },
+                          "secure": {
+                            "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "strategy": {
+                    "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                    "enum": [
+                      "wrr",
+                      "p2c",
+                      "hrw",
+                      "leasttime",
+                      "RoundRobin"
+                    ],
+                    "type": "string"
+                  },
+                  "weight": {
+                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mirroring": {
+          "description": "Mirroring defines the Mirroring service configuration.",
+          "properties": {
+            "healthCheck": {
+              "description": "Healthcheck defines health checks for ExternalName services.",
+              "properties": {
+                "followRedirects": {
+                  "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                  "type": "boolean"
+                },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                  "type": "object"
+                },
+                "hostname": {
+                  "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                  "type": "string"
+                },
+                "interval": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                  "x-kubernetes-int-or-string": true
+                },
+                "method": {
+                  "description": "Method defines the healthcheck method.",
+                  "type": "string"
+                },
+                "mode": {
+                  "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Path defines the server URL path for the health check endpoint.",
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port defines the server URL port for the health check endpoint.",
+                  "type": "integer"
+                },
+                "scheme": {
+                  "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                  "type": "string"
+                },
+                "status": {
+                  "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                  "type": "integer"
+                },
+                "timeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                  "x-kubernetes-int-or-string": true
+                },
+                "unhealthyInterval": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind defines the kind of the Service.",
+              "enum": [
+                "Service",
+                "TraefikService"
+              ],
+              "type": "string"
+            },
+            "maxBodySize": {
+              "description": "MaxBodySize defines the maximum size allowed for the body of the request.\nIf the body is larger, the request is not mirrored.\nDefault value is -1, which means unlimited size.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "middlewares": {
+              "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+              "items": {
+                "description": "MiddlewareRef is a reference to a Middleware resource.",
+                "properties": {
+                  "name": {
+                    "description": "Name defines the name of the referenced Middleware resource.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mirrorBody": {
+              "description": "MirrorBody defines whether the body of the request should be mirrored.\nDefault value is true.",
+              "type": "boolean"
+            },
+            "mirrors": {
+              "description": "Mirrors defines the list of mirrors where Traefik will duplicate the traffic.",
+              "items": {
+                "description": "MirrorService holds the mirror configuration.",
+                "properties": {
+                  "healthCheck": {
+                    "description": "Healthcheck defines health checks for ExternalName services.",
+                    "properties": {
+                      "followRedirects": {
+                        "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                        "type": "boolean"
+                      },
+                      "headers": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                        "type": "object"
+                      },
+                      "hostname": {
+                        "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                        "type": "string"
+                      },
+                      "interval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "method": {
+                        "description": "Method defines the healthcheck method.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path defines the server URL path for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Port defines the server URL port for the health check endpoint.",
+                        "type": "integer"
+                      },
+                      "scheme": {
+                        "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                        "type": "integer"
+                      },
+                      "timeout": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "unhealthyInterval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kind": {
+                    "description": "Kind defines the kind of the Service.",
+                    "enum": [
+                      "Service",
+                      "TraefikService"
+                    ],
+                    "type": "string"
+                  },
+                  "middlewares": {
+                    "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                    "items": {
+                      "description": "MiddlewareRef is a reference to a Middleware resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name defines the name of the referenced Middleware resource.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                    "type": "string"
+                  },
+                  "nativeLB": {
+                    "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                    "type": "boolean"
+                  },
+                  "nodePortLB": {
+                    "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                    "type": "boolean"
+                  },
+                  "passHostHeader": {
+                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                    "type": "boolean"
+                  },
+                  "passiveHealthCheck": {
+                    "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                    "properties": {
+                      "failureWindow": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "maxFailedAttempts": {
+                        "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "percent": {
+                    "description": "Percent defines the part of the traffic to mirror.\nSupported values: 0 to 100.",
+                    "type": "integer"
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "responseForwarding": {
+                    "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                    "properties": {
+                      "flushInterval": {
+                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scheme": {
+                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                    "type": "string"
+                  },
+                  "serversTransport": {
+                    "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                    "type": "string"
+                  },
+                  "sticky": {
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                    "properties": {
+                      "cookie": {
+                        "description": "Cookie defines the sticky cookie configuration.",
+                        "properties": {
+                          "domain": {
+                            "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                            "type": "string"
+                          },
+                          "httpOnly": {
+                            "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                            "type": "boolean"
+                          },
+                          "maxAge": {
+                            "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name defines the Cookie name.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                            "type": "string"
+                          },
+                          "sameSite": {
+                            "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "enum": [
+                              "none",
+                              "lax",
+                              "strict",
+                              "None",
+                              "Lax",
+                              "Strict"
+                            ],
+                            "type": "string"
+                          },
+                          "secure": {
+                            "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "strategy": {
+                    "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                    "enum": [
+                      "wrr",
+                      "p2c",
+                      "hrw",
+                      "leasttime",
+                      "RoundRobin"
+                    ],
+                    "type": "string"
+                  },
+                  "weight": {
+                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+              "type": "string"
+            },
+            "nativeLB": {
+              "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+              "type": "boolean"
+            },
+            "nodePortLB": {
+              "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+              "type": "boolean"
+            },
+            "passHostHeader": {
+              "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+              "type": "boolean"
+            },
+            "passiveHealthCheck": {
+              "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+              "properties": {
+                "failureWindow": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxFailedAttempts": {
+                  "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+              "x-kubernetes-int-or-string": true
+            },
+            "responseForwarding": {
+              "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+              "properties": {
+                "flushInterval": {
+                  "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scheme": {
+              "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+              "type": "string"
+            },
+            "serversTransport": {
+              "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+              "type": "string"
+            },
+            "sticky": {
+              "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+              "properties": {
+                "cookie": {
+                  "description": "Cookie defines the sticky cookie configuration.",
+                  "properties": {
+                    "domain": {
+                      "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                      "type": "string"
+                    },
+                    "httpOnly": {
+                      "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                      "type": "boolean"
+                    },
+                    "maxAge": {
+                      "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "Name defines the Cookie name.",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                      "type": "string"
+                    },
+                    "sameSite": {
+                      "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "enum": [
+                        "none",
+                        "lax",
+                        "strict",
+                        "None",
+                        "Lax",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    },
+                    "secure": {
+                      "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "strategy": {
+              "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+              "enum": [
+                "wrr",
+                "p2c",
+                "hrw",
+                "leasttime",
+                "RoundRobin"
+              ],
+              "type": "string"
+            },
+            "weight": {
+              "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "weighted": {
+          "description": "Weighted defines the Weighted Round Robin configuration.",
+          "properties": {
+            "services": {
+              "description": "Services defines the list of Kubernetes Service and/or TraefikService to load-balance, with weight.",
+              "items": {
+                "description": "Service defines an upstream HTTP service to proxy traffic to.",
+                "properties": {
+                  "healthCheck": {
+                    "description": "Healthcheck defines health checks for ExternalName services.",
+                    "properties": {
+                      "followRedirects": {
+                        "description": "FollowRedirects defines whether redirects should be followed during the health check calls.\nDefault: true",
+                        "type": "boolean"
+                      },
+                      "headers": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Headers defines custom headers to be sent to the health check endpoint.",
+                        "type": "object"
+                      },
+                      "hostname": {
+                        "description": "Hostname defines the value of hostname in the Host header of the health check request.",
+                        "type": "string"
+                      },
+                      "interval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "method": {
+                        "description": "Method defines the healthcheck method.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "Mode defines the health check mode.\nIf defined to grpc, will use the gRPC health check protocol to probe the server.\nDefault: http",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path defines the server URL path for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Port defines the server URL port for the health check endpoint.",
+                        "type": "integer"
+                      },
+                      "scheme": {
+                        "description": "Scheme replaces the server URL scheme for the health check endpoint.",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status defines the expected HTTP status code of the response to the health check request.",
+                        "type": "integer"
+                      },
+                      "timeout": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "unhealthyInterval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kind": {
+                    "description": "Kind defines the kind of the Service.",
+                    "enum": [
+                      "Service",
+                      "TraefikService"
+                    ],
+                    "type": "string"
+                  },
+                  "middlewares": {
+                    "description": "Middlewares defines the list of references to Middleware resources to apply to the service.",
+                    "items": {
+                      "description": "MiddlewareRef is a reference to a Middleware resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name defines the name of the referenced Middleware resource.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace defines the namespace of the referenced Middleware resource.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.",
+                    "type": "string"
+                  },
+                  "nativeLB": {
+                    "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
+                    "type": "boolean"
+                  },
+                  "nodePortLB": {
+                    "description": "NodePortLB controls, when creating the load-balancer,\nwhether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.\nIt allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.\nBy default, NodePortLB is false.",
+                    "type": "boolean"
+                  },
+                  "passHostHeader": {
+                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
+                    "type": "boolean"
+                  },
+                  "passiveHealthCheck": {
+                    "description": "PassiveHealthCheck defines passive health checks for ExternalName services.",
+                    "properties": {
+                      "failureWindow": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "FailureWindow defines the time window during which the failed attempts must occur for the server to be marked as unhealthy. It also defines for how long the server will be considered unhealthy.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "maxFailedAttempts": {
+                        "description": "MaxFailedAttempts is the number of consecutive failed attempts allowed within the failure window before marking the server as unhealthy.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "responseForwarding": {
+                    "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
+                    "properties": {
+                      "flushInterval": {
+                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scheme": {
+                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
+                    "type": "string"
+                  },
+                  "serversTransport": {
+                    "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
+                    "type": "string"
+                  },
+                  "sticky": {
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#sticky-sessions",
+                    "properties": {
+                      "cookie": {
+                        "description": "Cookie defines the sticky cookie configuration.",
+                        "properties": {
+                          "domain": {
+                            "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                            "type": "string"
+                          },
+                          "httpOnly": {
+                            "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                            "type": "boolean"
+                          },
+                          "maxAge": {
+                            "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name defines the Cookie name.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                            "type": "string"
+                          },
+                          "sameSite": {
+                            "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "enum": [
+                              "none",
+                              "lax",
+                              "strict",
+                              "None",
+                              "Lax",
+                              "Strict"
+                            ],
+                            "type": "string"
+                          },
+                          "secure": {
+                            "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "strategy": {
+                    "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                    "enum": [
+                      "wrr",
+                      "p2c",
+                      "hrw",
+                      "leasttime",
+                      "RoundRobin"
+                    ],
+                    "type": "string"
+                  },
+                  "weight": {
+                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "sticky": {
+              "description": "Sticky defines whether sticky sessions are enabled.\nMore info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/kubernetes/crd/http/traefikservice/#stickiness-and-load-balancing",
+              "properties": {
+                "cookie": {
+                  "description": "Cookie defines the sticky cookie configuration.",
+                  "properties": {
+                    "domain": {
+                      "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                      "type": "string"
+                    },
+                    "httpOnly": {
+                      "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
+                      "type": "boolean"
+                    },
+                    "maxAge": {
+                      "description": "MaxAge defines the number of seconds until the cookie expires.\nWhen set to a negative number, the cookie expires immediately.\nWhen set to zero, the cookie never expires.",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "Name defines the Cookie name.",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path defines the path that must exist in the requested URL for the browser to send the Cookie header.\nWhen not provided the cookie will be sent on every request to the domain.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value",
+                      "type": "string"
+                    },
+                    "sameSite": {
+                      "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "enum": [
+                        "none",
+                        "lax",
+                        "strict",
+                        "None",
+                        "Lax",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    },
+                    "secure": {
+                      "description": "Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object",
+  "additionalProperties": false
+}

--- a/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
+++ b/argocd-applications/environments/scaleway-parca-demo/main.jsonnet
@@ -51,7 +51,20 @@ local applications =
     u.newJsonnetApp(common {
       name: 'monitoring',
       namespace: 'monitoring',
-    }),
+    }) {
+      spec+: {
+        ignoreDifferences: [{
+          // The real Authorization/project-ID header values are patched live onto this
+          // Middleware post-sync (see monitoring/README.md) and are never declared in
+          // git, so ignore them here to avoid a permanent OutOfSync status.
+          group: 'traefik.io',
+          kind: 'Middleware',
+          name: 'psc-remote-write-headers',
+          namespace: 'parca-analytics',
+          jsonPointers: ['/spec/headers/customRequestHeaders'],
+        }],
+      },
+    },
     u.newHelmApp(common {
       name: 'oauth2-proxy',
       namespace: 'oauth2-proxy',

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -28,3 +28,22 @@ jq -Rs '{"data": {"thanos.yaml": .|@base64 }}' /tmp/thanos.yaml \
 ```
 
 This will unblock the parca-analytics Prometheus Pod and it will start uploading data to the object storage.
+
+## Mirroring parca-analytics remote-write to Polar Signals Cloud
+
+`analytics.parca.dev/api/v1/write` mirrors every remote-write request to Polar
+Signals Cloud in addition to the primary write into the local Prometheus, via a
+Traefik `Mirroring` TraefikService. The `Authorization`/project-ID headers added to
+the mirrored (and, unavoidably, the primary) request are not committed to git —
+the `psc-remote-write-headers` Middleware is committed with an empty
+`customRequestHeaders`, and the ArgoCD `monitoring` Application has an
+`ignoreDifferences` entry for that field so live patches survive future syncs.
+
+Once you have a Polar Signals Cloud API token and project ID, patch them in:
+
+```bash
+kubectl --namespace=parca-analytics patch middleware psc-remote-write-headers \
+  --type=merge -p '{"spec":{"headers":{"customRequestHeaders":{
+    "Authorization":"Bearer <token>","<project-id-header>":"<project-id>"
+  }}}}'
+```

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -145,46 +145,117 @@ local prometheuses = [
       },
     },
 
-    ingressRemoteWrite: {
-      apiVersion: 'networking.k8s.io/v1',
-      kind: 'Ingress',
+    // Mirrors parca-analytics remote-write traffic to Polar Signals Cloud, in addition
+    // to the primary write into this Prometheus. First route in this repo on the
+    // Traefik-native CRDs (IngressRoute/Middleware/TraefikService/ServersTransport)
+    // rather than the nginx-compat Ingress provider — a scoped exception ahead of the
+    // broader native-Traefik migration.
+
+    polarSignalsCloudService: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'polarsignals-cloud',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        type: 'ExternalName',
+        externalName: 'cloud.polarsignals.com',
+        ports: [{ name: 'https', port: 443 }],
+      },
+    },
+
+    polarSignalsCloudServersTransport: {
+      apiVersion: 'traefik.io/v1alpha1',
+      kind: 'ServersTransport',
+      metadata: {
+        name: 'polarsignals-cloud',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        serverName: 'cloud.polarsignals.com',
+      },
+    },
+
+    // Real Authorization/project-ID header values are patched onto this live, see
+    // monitoring/README.md; committed empty here, matching the empty-shell pattern
+    // used by objectStorageSecret below. Traefik runs this Middleware once, before
+    // the mirroring service fans the request out, so both the primary write and the
+    // mirrored copy receive these headers — harmless, since the local Prometheus
+    // remote-write receiver has no auth configured and ignores headers it doesn't
+    // recognize.
+    remoteWriteHeadersMiddleware: {
+      apiVersion: 'traefik.io/v1alpha1',
+      kind: 'Middleware',
+      metadata: {
+        name: 'psc-remote-write-headers',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        headers: {
+          customRequestHeaders: {},
+        },
+      },
+    },
+
+    remoteWriteMirror: {
+      apiVersion: 'traefik.io/v1alpha1',
+      kind: 'TraefikService',
+      metadata: {
+        name: 'parca-analytics-mirror',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        mirroring: {
+          name: p.service.metadata.name,
+          port: 9090,
+          mirrorBody: true,
+          // Bound the mirror buffer (Traefik's memory has been unstable on this
+          // cluster). Batches larger than this are simply not mirrored; the
+          // primary write into the local Prometheus is unaffected either way.
+          maxBodySize: 4194304,
+          mirrors: [{
+            name: p.polarSignalsCloudService.metadata.name,
+            port: 443,
+            scheme: 'https',
+            serversTransport: p.polarSignalsCloudServersTransport.metadata.name,
+            percent: 100,
+          }],
+        },
+      },
+    },
+
+    remoteWriteIngressRoute: {
+      apiVersion: 'traefik.io/v1alpha1',
+      kind: 'IngressRoute',
       metadata: {
         name: p._config.name + '-remote-write',
         namespace: p._config.namespace,
         labels: p._config.commonLabels,
-        annotations: {
-          'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
-        },
       },
       spec: {
-        ingressClassName: p._config.ingress.class,
-        rules: [
+        entryPoints: ['websecure'],
+        routes: [
           {
-            host: host,
-            http: {
-              paths: [{
-                backend: {
-                  service: {
-                    name: p.service.metadata.name,
-                    port: {
-                      name: p.service.spec.ports[0].name,
-                    },
-                  },
-                },
-                path: '/api/v1/write',
-                pathType: 'Prefix',
-              }],
-            },
+            kind: 'Rule',
+            match: 'Host(`%s`) && PathPrefix(`/api/v1/write`)' % host,
+            middlewares: [{ name: p.remoteWriteHeadersMiddleware.metadata.name }],
+            services: [{
+              name: p.remoteWriteMirror.metadata.name,
+              kind: 'TraefikService',
+            }],
           }
           for host in p._config.ingress.hosts
         ],
-        tls: [
-          {
-            hosts: [host],
-            secretName: host,
-          }
-          for host in p._config.ingress.hosts
-        ],
+        // spec.tls is a single object (unlike Ingress' tls list); ingress.hosts has
+        // exactly one entry (analytics.parca.dev), which is also the cert secret name.
+        tls: {
+          secretName: p._config.ingress.hosts[0],
+        },
       },
     },
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -29,6 +29,10 @@ traefik:
     kubernetesCRD:
       # Needed for the native Middleware/IngressRoute CRDs we switch to in the final phase.
       enabled: true
+      # Required for the parca-analytics remote-write mirror to Polar Signals Cloud,
+      # whose upstream Service is an ExternalName. Off by default in Traefik v3;
+      # without it, a mirror to an ExternalName Service is silently dropped.
+      allowExternalNameServices: true
 
   # Dashboard/API only bind to the "traefik" entrypoint (port 8080), which the
   # LoadBalancer Service never exposes (only web/websecure are published) — so


### PR DESCRIPTION
Mirrors parca-analytics remote-write traffic to Polar Signals Cloud in addition to the primary write into the local Prometheus, using a Traefik Mirroring TraefikService so a slow or down cloud endpoint never delays the primary write. This is the first route in the repo on Traefik-native CRDs (IngressRoute/Middleware/TraefikService/ServersTransport) rather than the nginx-compat provider, a scoped exception ahead of the broader native-Traefik migration.

Auth headers are injected via a Middleware committed with empty `customRequestHeaders` and patched live post-merge (see `monitoring/README.md`), with an `ignoreDifferences` entry on the `monitoring` ArgoCD Application so the live patch doesn't show as OutOfSync. Body mirroring is bounded to 4 MiB given Traefik's recent memory-pressure history on this cluster.