### PR TITLE
fix(monitoring): bound Polar Signals Cloud mirror request timeouts

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -176,6 +176,17 @@ local prometheuses = [
       },
       spec: {
         serverName: 'cloud.polarsignals.com',
+        // Without these, Traefik's HTTP client waits indefinitely for a slow/dead
+        // mirror target. Since mirrorBody buffers each request's full body in memory
+        // until the mirror completes or fails, an unresponsive Polar Signals Cloud
+        // endpoint queues up buffered bodies faster than they're freed at this
+        // request volume (~1.8k req/s) and OOM-kills Traefik within seconds. Failing
+        // fast bounds how long any single request can hold its buffer.
+        forwardingTimeouts: {
+          dialTimeout: '5s',
+          responseHeaderTimeout: '5s',
+          idleConnTimeout: '30s',
+        },
       },
     },
 


### PR DESCRIPTION
Traefik has been OOM-killing itself within seconds of the parca-analytics remote-write mirror (#460) going live. The `polarsignals-cloud` ServersTransport had no `forwardingTimeouts`, so a slow/unresponsive mirror target lets Traefik's client hang on response headers indefinitely while holding each mirrored request's buffered body (`mirrorBody: true`) in memory. At ~1.8k req/s that's enough to blow through the 4Gi limit in well under a minute.

Sets `dialTimeout`/`responseHeaderTimeout` to 5s and `idleConnTimeout` to 30s so a dead or slow mirror target fails fast instead of accumulating buffered bodies. I already live-patched this onto the cluster to stop the bleeding, but that patch will get reverted on the next ArgoCD auto-sync since `ServersTransport` has no `ignoreDifferences`, so this needs to land in git.