### PR TITLE
fix(monitoring): mirror to api.polarsignals.com, not cloud.polarsignals.com

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -161,7 +161,7 @@ local prometheuses = [
       },
       spec: {
         type: 'ExternalName',
-        externalName: 'cloud.polarsignals.com',
+        externalName: 'api.polarsignals.com',
         ports: [{ name: 'https', port: 443 }],
       },
     },
@@ -175,7 +175,7 @@ local prometheuses = [
         labels: p._config.commonLabels,
       },
       spec: {
-        serverName: 'cloud.polarsignals.com',
+        serverName: 'api.polarsignals.com',
         // Without these, Traefik's HTTP client waits indefinitely for a slow/dead
         // mirror target. Since mirrorBody buffers each request's full body in memory
         // until the mirror completes or fails, an unresponsive Polar Signals Cloud


### PR DESCRIPTION
The mirroring config (#456/#460) pointed at `cloud.polarsignals.com`, which is the Polar Signals Cloud web UI frontend, not the remote-write ingest endpoint. Confirmed against the polarsignals monorepo: `api.polarsignals.com` is where `POST /api/v1/write` is actually served (see `httproute-api-polarsignals-com.yaml` and `pkg/api/prometheus/remotewrite/receiver.go`); `cloud.polarsignals.com` is UI-only (OAuth redirects, CORS origin, invite links).

This is almost certainly the real cause behind the OOM crash loop from #461's forwardingTimeouts fix not fully resolving things: every mirrored request was hanging against a host that was never going to accept it, hitting the timeout on every single request instead of occasionally. Already live-patched onto the cluster to unblock; this lands it in git so it survives the next ArgoCD sync.