### PR TITLE
fix(monitoring): mirror only 1% of parca-analytics remote-write traffic

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -234,7 +234,7 @@ local prometheuses = [
             port: 443,
             scheme: 'https',
             serversTransport: p.polarSignalsCloudServersTransport.metadata.name,
-            percent: 100,
+            percent: 1,
           }],
         },
       },


### PR DESCRIPTION
100% mirroring has been OOM-killing Traefik within seconds of any replica going Ready, even after fixing the mirror hostname (#462) and bounding forwardingTimeouts (#461). A single cold-started replica absorbing the full ~1.8k req/s of primary write plus a fully mirrored copy is too much at once.

Dropping to 1% to validate the mirror path lands cleanly end-to-end (correct host, valid auth, now confirmed working) without the memory blowup, then ramp up from there. Already live-patched onto the cluster.