### PR TITLE
fix(monitoring): ramp parca-analytics remote-write mirror to 50%

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -234,7 +234,7 @@ local prometheuses = [
             port: 443,
             scheme: 'https',
             serversTransport: p.polarSignalsCloudServersTransport.metadata.name,
-            percent: 1,
+            percent: 50,
           }],
         },
       },


### PR DESCRIPTION
1% (#463) has been running clean for several minutes with the corrected mirror host and auth grant: consistent 200s from Polar Signals Cloud, no OOM, no impact on the primary write into local Prometheus. Ramping to 50% as the next step toward 100%.