### PR TITLE
fix(monitoring): disable parca-analytics remote-write mirroring

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -234,7 +234,7 @@ local prometheuses = [
             port: 443,
             scheme: 'https',
             serversTransport: p.polarSignalsCloudServersTransport.metadata.name,
-            percent: 50,
+            percent: 0,
           }],
         },
       },


### PR DESCRIPTION
50% (#464) OOM-killed Traefik again within seconds of any replica going Ready, same failure mode as 100%. Setting to 0% now to stop the crash loop and restore remote-write while we move mirroring off Traefik entirely onto Prometheus's own \`remoteWrite\` (native support, no HTTP body buffering) in a follow-up PR.