### PR TITLE
feat(monitoring): add native remoteWrite to Polar Signals Cloud

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -47,3 +47,17 @@ kubectl --namespace=parca-analytics patch middleware psc-remote-write-headers \
     "Authorization":"Bearer <token>","<project-id-header>":"<project-id>"
   }}}}'
 ```
+
+## Sending parca-analytics data to Polar Signals Cloud via remoteWrite
+
+The parca-analytics Prometheus has a second `remoteWrite` target pointing
+directly at Polar Signals Cloud. The token is not committed to git — the
+`polarsignals-cloud` Secret is committed with no `data` at all, matching the
+`objectStorageSecret` pattern above. Once you have a Polar Signals Cloud API
+token, patch it in:
+
+```bash
+kubectl --namespace=parca-analytics create secret generic polarsignals-cloud \
+  --from-literal=token=<token> --dry-run=client -o yaml \
+  | kubectl apply -f -
+```

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -273,6 +273,15 @@ local prometheuses = [
     prometheus+: {
       spec+: {
         enableRemoteWriteReceiver: true,
+        remoteWrite: [{
+          url: 'https://api.polarsignals.com/api/v1/write',
+          authorization: {
+            credentials: { name: p.polarSignalsCloudSecret.metadata.name, key: 'token' },
+          },
+          headers: {
+            projectID: '5a755043-1fb8-48fd-a2c8-2787498ec59d',
+          },
+        }],
         // This instance only ingests via remote-write and monitors its own Thanos
         // components. The default {} selectors match every PodMonitor/ServiceMonitor
         // cluster-wide, which would pull in unrelated apps (parca-agent, pyrra, ...).
@@ -302,6 +311,16 @@ local prometheuses = [
             },
           },
         },
+      },
+    },
+
+    polarSignalsCloudSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'polarsignals-cloud',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
       },
     },
 


### PR DESCRIPTION
Adds a second \`remoteWrite\` target on the parca-analytics Prometheus pointing directly at Polar Signals Cloud. Prometheus's own remote-write queue handles batching, backpressure and retries, and needs no changes on any agent writing into this Prometheus.

The token isn't committed to git — the \`polarsignals-cloud\` Secret ships with no \`data\` at all (same empty-shell pattern as \`objectStorageSecret\`); patch it in per \`monitoring/README.md\`.