### PR TITLE
fix(monitoring): scrape parca-analytics Prometheus from the parca instance

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -52,6 +52,8 @@ local prometheuses = [
       namespaces: ['parca', 'parca-devel', 'traefik', 'ingress-nginx', 'monitoring', 'parca-analytics'],
     },
   }) {
+    local p = self,
+
     prometheus+: {
       spec+: {
         remoteWrite: [{
@@ -68,12 +70,61 @@ local prometheuses = [
     // We do not monitor k8s metrics with this instance.
     clusterRole:: {},
     clusterRoleBinding:: {},
+
+    // The base library hides self-monitoring for every instance (see
+    // monitoring/lib/prometheus.libsonnet). This instance is the one that
+    // should scrape itself, so re-add it explicitly.
+    serviceMonitorSelf: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata: {
+        name: 'prometheus-parca',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        selector: { matchLabels: p.service.spec.selector },
+        endpoints: [
+          { port: 'web', interval: '30s' },
+          { port: 'reloader-web', interval: '30s' },
+        ],
+      },
+    },
+
+    // parca-analytics does not scrape itself (see below), so this instance
+    // scrapes it instead. Lives here, in this namespace, rather than in
+    // parca-analytics, so parca-analytics' own namespace-scoped
+    // serviceMonitorNamespaceSelector never discovers it.
+    serviceMonitorParcaAnalytics: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata: {
+        name: 'prometheus-parca-analytics',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        namespaceSelector: { matchNames: ['parca-analytics'] },
+        selector: {
+          matchLabels: {
+            'app.kubernetes.io/component': 'prometheus',
+            'app.kubernetes.io/instance': 'parca-analytics',
+            'app.kubernetes.io/name': 'prometheus',
+            'app.kubernetes.io/part-of': 'kube-prometheus',
+          },
+        },
+        endpoints: [
+          { port: 'web', interval: '30s' },
+          { port: 'reloader-web', interval: '30s' },
+        ],
+      },
+    },
   },
   m.prometheus({
     prometheus+:: {
       name: 'parca-analytics',
       namespace: 'parca-analytics',
-      namespaces: [],
+      namespaces: ['parca-analytics'],
       ingress: {
         class: 'nginx',
         hosts: ['analytics.parca.dev'],
@@ -341,6 +392,20 @@ local prometheuses = [
             namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
             podSelector: { matchLabels: { 'app.kubernetes.io/name': 'thanos-query' } },
           }],
+        }, {
+          // Scraped by the parca Prometheus (parca-analytics does not scrape itself).
+          from: [{
+            namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'monitoring' } },
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/component': 'prometheus',
+                'app.kubernetes.io/instance': 'parca',
+                'app.kubernetes.io/name': 'prometheus',
+                'app.kubernetes.io/part-of': 'kube-prometheus',
+              },
+            },
+          }],
+          ports: [{ port: 'web' }, { port: 'reloader-web' }],
         }],
       },
     },


### PR DESCRIPTION
Two related fixes:

1. **RBAC**: \`parca-analytics\` had \`namespaces: []\`, so no Role/RoleBinding was generated for it at all — not even its own namespace. That's been flooding its logs with \`Failed to watch ... is forbidden\` errors and breaking its own service discovery (thanos-query/thanos-store, self). Scopes it to \`['parca-analytics']\`.

2. **Self-monitoring**: neither Prometheus instance was being scraped at all — the base library (\`monitoring/lib/prometheus.libsonnet\`) hides \`serviceMonitor\` by default for every instance it builds. Adds a self-scrape \`ServiceMonitor\` for \`parca\`, and a second \`ServiceMonitor\` (also living in \`parca\`'s own \`monitoring\` namespace) that scrapes \`parca-analytics\` cross-namespace via \`spec.namespaceSelector\`. \`parca-analytics\` should not scrape itself, and since its own \`serviceMonitorNamespaceSelector\` only looks inside its own namespace, keeping this ServiceMonitor object in \`monitoring\` means it can never discover it. Also opens the matching NetworkPolicy ingress rule so the cross-namespace scrape isn't silently dropped by Cilium's default-deny.

Opened as draft to confirm CI first.