### PR TITLE
feat(monitoring): add SLO for parca-analytics remote-write to Polar Signals Cloud

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -375,6 +375,27 @@ local prometheuses = [
       },
     },
 
+    polarSignalsCloudRemoteWriteSLO: {
+      apiVersion: 'pyrra.dev/v1alpha1',
+      kind: 'ServiceLevelObjective',
+      metadata: {
+        name: p._config.name + '-remote-write',
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels { 'app.kubernetes.io/component': 'slo' },
+      },
+      spec: {
+        target: '99',
+        window: '4w',
+        description: 'Samples remote-written to Polar Signals Cloud are not dropped.',
+        indicator: {
+          ratio: {
+            errors: { metric: 'prometheus_remote_storage_samples_failed_total{url="https://api.polarsignals.com/api/v1/write"}' },
+            total: { metric: 'prometheus_remote_storage_samples_total{url="https://api.polarsignals.com/api/v1/write"}' },
+          },
+        },
+      },
+    },
+
     objectStorageSecret: {
       apiVersion: 'v1',
       kind: 'Secret',


### PR DESCRIPTION
Adds a Pyrra \`ServiceLevelObjective\` for the parca-analytics Prometheus's remote-write to Polar Signals Cloud, using its own remote-write client metrics:

- errors: \`prometheus_remote_storage_samples_failed_total{url="https://api.polarsignals.com/api/v1/write"}\`
- total: \`prometheus_remote_storage_samples_total{url="https://api.polarsignals.com/api/v1/write"}\`

Targets 99% over 4 weeks. Current real-world success rate is 100% (0 failed samples out of ~4.7M over the last 7 days), so there's plenty of error budget margin.

Co-located in \`monitoring/\` alongside the parca-analytics Prometheus itself, matching the existing \`objectStorageSecret\`/\`polarSignalsCloudSecret\` pattern in the same file.

Opened as draft to confirm CI first.