### PR TITLE
fix(monitoring): use a valid match-nothing selector for parca-analytics

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -338,11 +338,13 @@ local prometheuses = [
         // job, see monitoring's serviceMonitorParcaAnalytics). The default {}
         // selectors match every PodMonitor/ServiceMonitor cluster-wide, so without
         // this it would also pick up unrelated apps (parca-agent, pyrra, ...) plus
-        // its own Thanos components. `In: []` never matches, regardless of labels.
+        // its own Thanos components. matchLabels on a label nothing carries never
+        // matches; unlike `In: []`, the Kubernetes API accepts this (`In`/`NotIn`
+        // reject empty values sets and fail Prometheus Operator's reconciliation).
         podMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
         serviceMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
-        podMonitorSelector: { matchExpressions: [{ key: 'prometheus', operator: 'In', values: [] }] },
-        serviceMonitorSelector: { matchExpressions: [{ key: 'prometheus', operator: 'In', values: [] }] },
+        podMonitorSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
+        serviceMonitorSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
         resources+: {
           requests+: { cpu: '500m' },
         },


### PR DESCRIPTION
Follow-up to #473, which merged but never actually took effect. Confirmed live via the Prometheus CR status:

```
message: "selecting ServiceMonitors failed: values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty"
reason: "ReconciliationFailed"
```

Kubernetes' own API validation rejects \`In\`/\`NotIn\` with an empty \`values\` set, so Prometheus Operator's reconciliation failed outright and it kept running its old scrape config — confirmed via port-forward, it was still scraping \`thanos-sidecar\`/\`thanos-query\`/\`thanos-store\`.

Switches to \`matchLabels\` on a label nothing carries, which has no such constraint and still reliably matches zero ServiceMonitors/PodMonitors.

Opened as draft to confirm CI first.