### PR TITLE
fix(monitoring): stop parca-analytics from loading PrometheusRules

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -345,6 +345,13 @@ local prometheuses = [
         serviceMonitorNamespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': p._config.namespace } },
         podMonitorSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
         serviceMonitorSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
+        // Same reasoning as the PodMonitor/ServiceMonitor selectors above: this
+        // instance shouldn't evaluate any rules either. The default {} ruleSelector
+        // was loading every PrometheusRule it has RBAC for, including its own
+        // thanos-sidecar-rules, which populated ALERTS/ALERTS_FOR_STATE series that
+        // then got swept up by remote-write to Polar Signals Cloud.
+        ruleNamespaceSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
+        ruleSelector: { matchLabels: { 'prometheus-operator-select-nothing': 'true' } },
         resources+: {
           requests+: { cpu: '500m' },
         },


### PR DESCRIPTION
`ruleSelector``ruleNamespaceSelector` were still at the `{}` default, so this instance was loading and evaluating every `PrometheusRule` it has RBAC for — including its own `thanos-sidecar-rules`, which is now orphaned anyway since the sidecar isn't scraped either (#473/#474). Evaluating those rules generates `ALERTS``ALERTS_FOR_STATE` series locally, and remote-write forwards everything in local storage, not just scraped series, so they got swept up too.

Same match-nothing pattern as the PodMonitor/ServiceMonitor selectors: parca-analytics only ingests via remote-write, it shouldn't scrape or evaluate rules at all.

Opened as draft to confirm CI first.