### PR TITLE
fix(monitoring): stop tracking the polarsignals-cloud Secret in ArgoCD

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -51,13 +51,22 @@ kubectl --namespace=parca-analytics patch middleware psc-remote-write-headers \
 ## Sending parca-analytics data to Polar Signals Cloud via remoteWrite
 
 The parca-analytics Prometheus has a second `remoteWrite` target pointing
-directly at Polar Signals Cloud. The token is not committed to git — the
-`polarsignals-cloud` Secret is committed with no `data` at all, matching the
-`objectStorageSecret` pattern above. Once you have a Polar Signals Cloud API
-token, patch it in:
+directly at Polar Signals Cloud. The token is not committed to git, and unlike
+`objectStorageSecret`, the `polarsignals-cloud` Secret isn't declared in git
+at all — it's created directly in the cluster and left untracked by ArgoCD,
+so a sync can never prune or reset it. Once you have a Polar Signals Cloud API
+token, create it:
 
 ```bash
 kubectl --namespace=parca-analytics create secret generic polarsignals-cloud \
-  --from-literal=token=<token> --dry-run=client -o yaml \
-  | kubectl apply -f -
+  --from-literal=token=<token>
+```
+
+If the Secret already exists with ArgoCD's `argocd.argoproj.io/tracking-id`
+annotation on it (e.g. left over from before this Secret was untracked),
+remove that annotation so `prune: true` syncs leave it alone:
+
+```bash
+kubectl --namespace=parca-analytics annotate secret polarsignals-cloud \
+  argocd.argoproj.io/tracking-id-
 ```

--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -327,7 +327,11 @@ local prometheuses = [
         remoteWrite: [{
           url: 'https://api.polarsignals.com/api/v1/write',
           authorization: {
-            credentials: { name: p.polarSignalsCloudSecret.metadata.name, key: 'token' },
+            // Deliberately not the polarSignalsCloudSecret object it once was: this
+            // Secret is created directly in the cluster, untracked by ArgoCD (see
+            // monitoring/README.md), so nothing ever prunes or resyncs its token
+            // away. Referencing it by name here is the only coupling left.
+            credentials: { name: 'polarsignals-cloud', key: 'token' },
           },
           headers: {
             projectID: '5a755043-1fb8-48fd-a2c8-2787498ec59d',
@@ -376,16 +380,6 @@ local prometheuses = [
             },
           },
         },
-      },
-    },
-
-    polarSignalsCloudSecret: {
-      apiVersion: 'v1',
-      kind: 'Secret',
-      metadata: {
-        name: 'polarsignals-cloud',
-        namespace: p._config.namespace,
-        labels: p._config.commonLabels,
       },
     },
 


### PR DESCRIPTION
The empty-shell-plus-live-patch pattern for this Secret (matching `objectStorageSecret`) has broken remote-write to Polar Signals Cloud twice in a row now, immediately after two separate unrelated syncs of this Application — the `token` key went missing both times, confirmed via the Prometheus CR's own reconciliation error (`key "token" in secret "polarsignals-cloud" not found`), and required manually recreating it each time.

Rather than chase down the exact SSA/sync mechanism responsible, this removes the `Secret` object from git entirely. This repo tracks ArgoCD-owned resources by the `argocd.argoproj.io/tracking-id` annotation, so an object that was never applied with that annotation is completely invisible to sync and prune — nothing in a future sync can touch it again. The Prometheus CR keeps referencing it by name (`polarsignals-cloud`)/key (`token`); only the object that used to provision the empty shell is gone.

Requires a manual step outside this PR (see updated `monitoring/README.md`): if the live Secret still carries the ArgoCD tracking annotation from before, it needs to be stripped so `prune: true` doesn't delete it on the next sync.

Opened as draft to confirm CI first.