### PR TITLE
fix(monitoring): allow parca Prometheus to reach parca-analytics' Thanos pods

### DIFF
--- a/monitoring/environments/scaleway-parca-demo/main.jsonnet
+++ b/monitoring/environments/scaleway-parca-demo/main.jsonnet
@@ -36,7 +36,43 @@ local kubeThanos = m.kubeThanos({
             }],
             ports: [{ port: 'http', protocol: 'TCP' }],
           },
+          {
+            // Scraped by the parca Prometheus (parca-analytics does not scrape itself).
+            from: [{
+              namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'monitoring' } },
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/component': 'prometheus',
+                  'app.kubernetes.io/instance': 'parca',
+                  'app.kubernetes.io/name': 'prometheus',
+                  'app.kubernetes.io/part-of': 'kube-prometheus',
+                },
+              },
+            }],
+            ports: [{ port: 'http', protocol: 'TCP' }],
+          },
         ],
+      },
+    },
+  },
+  store+: {
+    networkPolicy+: {
+      spec+: {
+        ingress+: [{
+          // Scraped by the parca Prometheus (parca-analytics does not scrape itself).
+          from: [{
+            namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'monitoring' } },
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/component': 'prometheus',
+                'app.kubernetes.io/instance': 'parca',
+                'app.kubernetes.io/name': 'prometheus',
+                'app.kubernetes.io/part-of': 'kube-prometheus',
+              },
+            },
+          }],
+          ports: [{ port: 'http' }],
+        }],
       },
     },
   },
@@ -434,7 +470,9 @@ local prometheuses = [
               },
             },
           }],
-          ports: [{ port: 'web' }, { port: 'reloader-web' }],
+          // web/reloader-web are this Prometheus' own metrics; http is the
+          // Thanos sidecar's, which runs as a container on the same pod.
+          ports: [{ port: 'web' }, { port: 'reloader-web' }, { port: 'http' }],
         }],
       },
     },


### PR DESCRIPTION
Confirmed error: Error scraping target: Get "http://100.64.2.7:9090/metrics": context deadline exceeded — a timeout, not a connection refusal, consistent with Cilium's default-deny silently dropping the packets rather than rejecting them.

The parca Prometheus already has wide-open serviceMonitorSelector/serviceMonitorNamespaceSelector, so it's been discovering the thanos-query/thanos-sidecar/thanos-store ServiceMonitors in parca-analytics all along; it just couldn't reach the pods at the network layer.

Adds a matching ingress rule to each of the three relevant NetworkPolicies:
- thanos-query (port http, 9090)
- thanos-store (port http, 10902)
- the prometheus-parca-analytics pod, which also hosts the sidecar container (adds port http, 10902, to its existing parca-scrape rule alongside web/reloader-web)

All three now explicitly allow ingress from parca's pod (namespace monitoring, matching its own pod labels) on those ports only.

Opened as draft to confirm CI first.